### PR TITLE
[feat] 헤더 UI 및 인터랙션 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,35 @@
+import { Link, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { Link } from 'react-router-dom';
 import WebContainer from './common/WebContainer';
+import { useEffect, useState } from 'react';
+
+interface headerTypes {
+  isMain: boolean;
+  hideGradient: boolean;
+}
 
 const Header = () => {
+  const [hideGradient, setHideGradient] = useState<boolean>(true);
+  const location = useLocation();
+  const isMain = location.pathname === '/';
+
+  const showHeaderGradientBackground = () => {
+    const { scrollY } = window;
+    scrollY > 700 ? setHideGradient(false) : setHideGradient(true);
+  };
+
+  useEffect(() => {
+    if (isMain) {
+      window.addEventListener('scroll', showHeaderGradientBackground);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', showHeaderGradientBackground);
+    };
+  }, [isMain]);
+
   return (
-    <HeaderContainer>
+    <HeaderContainer isMain={isMain} hideGradient={hideGradient}>
       <WebContainer>
         <HeaderWrapper>
           <LogoBoxH1>
@@ -13,7 +38,7 @@ const Header = () => {
           <Nav>
             <NavListUl>
               <NavItemLi>
-                <Link to={'/project/:id'}>새 글 쓰기</Link>
+                <Link to={'/project/write'}>새 글 쓰기</Link>
               </NavItemLi>
               <NavItemLi>
                 <Link to={'/findproject'}>팀원찾기</Link>
@@ -31,8 +56,17 @@ const Header = () => {
 
 export default Header;
 
-const HeaderContainer = styled.header`
+const HeaderContainer = styled.header<headerTypes>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 90;
   width: 100%;
+  background-image: ${(props) =>
+    props.isMain && props.hideGradient
+      ? 'linear-gradient(180deg, rgba(108, 108, 108, 0.47) 0%, rgba(217, 217, 217, 0) 100.87%)'
+      : 'none'};
+  background-color: ${(props) => (props.isMain ? 'transparent' : '#fff')};
 `;
 
 const HeaderWrapper = styled.div`
@@ -57,6 +91,7 @@ const NavListUl = styled.ul`
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  margin-right: 1.438rem;
 `;
 
 const NavItemLi = styled.li`

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,64 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import WebContainer from './common/WebContainer';
 
 const Header = () => {
-  return <div>Header</div>;
+  return (
+    <HeaderContainer>
+      <WebContainer>
+        <HeaderWrapper>
+          <LogoBoxH1>Detto</LogoBoxH1>
+          <Nav>
+            <NavListUl>
+              <NavItemLi>새 글 쓰기</NavItemLi>
+              <NavItemLi>팀원찾기</NavItemLi>
+              <NavItemLi>쪽지</NavItemLi>
+              <NavItemLi>알림</NavItemLi>
+              <NavItemLi>로그인하기</NavItemLi>
+            </NavListUl>
+          </Nav>
+        </HeaderWrapper>
+      </WebContainer>
+    </HeaderContainer>
+  );
 };
 
 export default Header;
+
+const HeaderContainer = styled.header`
+  width: 100%;
+`;
+
+const HeaderWrapper = styled.div`
+  margin: 1.875rem 0.625rem;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const LogoBoxH1 = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: #5d50f0;
+  margin-left: 1.438rem;
+  cursor: pointer;
+`;
+
+const Nav = styled.nav``;
+
+const NavListUl = styled.ul`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const NavItemLi = styled.li`
+  margin-right: 2.625rem;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #4e5968;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 import WebContainer from './common/WebContainer';
 
 const Header = () => {
@@ -6,11 +7,17 @@ const Header = () => {
     <HeaderContainer>
       <WebContainer>
         <HeaderWrapper>
-          <LogoBoxH1>Detto</LogoBoxH1>
+          <LogoBoxH1>
+            <Link to={'/'}> Detto</Link>
+          </LogoBoxH1>
           <Nav>
             <NavListUl>
-              <NavItemLi>새 글 쓰기</NavItemLi>
-              <NavItemLi>팀원찾기</NavItemLi>
+              <NavItemLi>
+                <Link to={'/project/:id'}>새 글 쓰기</Link>
+              </NavItemLi>
+              <NavItemLi>
+                <Link to={'/findproject'}>팀원찾기</Link>
+              </NavItemLi>
               <NavItemLi>쪽지</NavItemLi>
               <NavItemLi>알림</NavItemLi>
               <NavItemLi>로그인하기</NavItemLi>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -32,7 +32,7 @@ const Router = () => {
           <Route path="/findproject" element={<FindProjectComponentPage />} />
           <Route path="/project/:id" element={<ProjectDetailComponentPage />} />
           <Route
-            path="/project/write/:id"
+            path="/project/write"
             element={<ProjectWriteComponentPage />}
           />
           <Route


### PR DESCRIPTION
## 개요 🔎 #1 

헤더 UI를 완성하기 위한 PR입니다.

## 작업사항 📝

* 헤더 UI 추가
* 페이지 이동 링크 설정 
* 메인페이지일 경우 헤더 배경 그라데이션 설정
* 메인페이지일 경우 하단으로 스크롤 시 특정영역(현재는 700px로 설정)을 벗어나면 배경 하얀색 고정


## 패키지 설치내용 📦
.