### PR TITLE
[fix] 헤더 UI 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,6 +46,7 @@ const Header = () => {
           </LogoBoxH1>
           <Nav>
             <NavListUl>
+              {/* TODO :: 쪽지, 알림, 마이페이지, 로그아웃은 로그인 되었을 경우에만 보이도록 로직 추가 필요 */}
               <NavItemLi>
                 <Link to={'/project/write'}>새 글 쓰기</Link>
               </NavItemLi>
@@ -57,6 +58,11 @@ const Header = () => {
               <NavItemLi onClick={() => openModal('login', 0)}>
                 로그인하기
               </NavItemLi>
+              {/* 임시 주석처리 */}
+              {/* <NavItemLi>
+                <Link to={'/mypage'}>마이페이지</Link>
+              </NavItemLi>
+              <NavItemLi>로그아웃하기</NavItemLi> */}
             </NavListUl>
           </Nav>
         </HeaderWrapper>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,9 @@ interface headerTypes {
   hideGradient: boolean;
 }
 
+// 메인 페이지에서 스크롤이 MAIN_SCROLL_Y 값 이상 되면 헤더의 배경색을 투명에서 하얀색으로 변경
+const MAIN_SCROLL_Y = 480;
+
 const Header = () => {
   const [hideGradient, setHideGradient] = useState<boolean>(true);
   const location = useLocation();
@@ -20,7 +23,7 @@ const Header = () => {
 
   const showHeaderGradientBackground = () => {
     const { scrollY } = window;
-    scrollY > 700 ? setHideGradient(false) : setHideGradient(true);
+    scrollY > MAIN_SCROLL_Y ? setHideGradient(false) : setHideGradient(true);
   };
 
   useEffect(() => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -70,11 +70,13 @@ const HeaderContainer = styled.header<headerTypes>`
   left: 0;
   z-index: 90;
   width: 100%;
-  background-image: ${(props) =>
-    props.isMain && props.hideGradient
+
+  background-image: ${({ isMain, hideGradient }) =>
+    isMain && hideGradient
       ? 'linear-gradient(180deg, rgba(108, 108, 108, 0.47) 0%, rgba(217, 217, 217, 0) 100.87%)'
       : 'none'};
-  background-color: ${(props) => (props.isMain ? 'transparent' : '#fff')};
+  background-color: ${({ hideGradient }) =>
+    hideGradient === true ? 'transparent' : '#fff'};
 `;
 
 const HeaderWrapper = styled.div`

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,5 @@
 import MainBanner from 'components/main/banner/MainBanner';
-import MainCalendar from 'components/main/calendar/MainCalendar';
+import MainCalendar from 'components/main/Calendar/MainCalendar';
 import WebContainer from 'components/common/WebContainer';
 import MainRecommendation from 'components/main/recommendation/MainRecommendation';
 const MainPage = () => {


### PR DESCRIPTION
## 개요 🔎 #30 

현재 메인페이지에서의 헤더 배경색이 배너 영역을 벗어 났을 때도 투명한 이슈, 
네비게이션에 마이페이지, 로그아웃 같은 빠진 UI 요소를 추가작업한 PR입니다.

## 작업사항 📝

* 메인 페이지 헤더 배경색 변환 이슈 해결
* 배경색 변환 시점 높이값 수정, 높이값 상수화
* nav에 마이페이지, 로그아웃 추가 (현재는 주석처리)

## 패키지 설치내용 📦

.