### PR TITLE
[feat] GitHub, Google 소셜 로그인 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,23 @@
 import { Global } from '@emotion/react';
+import { authService } from 'apis/firebaseService';
 import reset from 'assets/styles/globalStyled';
 import Router from 'routes/Router';
 
 function App() {
+  authService.onAuthStateChanged((user) => {
+    if (user) {
+      localStorage.setItem(
+        'user',
+        JSON.stringify({
+          uid: user.uid,
+          displayName: user.displayName,
+          email: user.email, // github의 경우 이메일 공개 여부에 따라 null로 할당되기도 함.
+          photoURL: user.photoURL,
+        }),
+      );
+    }
+  });
+
   return (
     <>
       <Global styles={reset} />

--- a/src/components/login/LoginPage0.tsx
+++ b/src/components/login/LoginPage0.tsx
@@ -1,30 +1,30 @@
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
-import { useGlobalModal } from 'hooks';
 import KEY_IMG from 'assets/images/login_key.png';
 import GITHUB_IMG from 'assets/images/login_github.png';
 import GOOGLE_IMG from 'assets/images/login_google.png';
 import KAKAO_IMG from 'assets/images/login_kakao.png';
+import useSocialLogin from 'hooks/useSocialLogin';
 
 // 페이지 0 : 로그인
 export default function LoginPage0() {
-  const { openModal } = useGlobalModal();
-
-  // 로그인 버튼 클릭 시 페이지 이동
-  const handleLoginButtonClick = () => {
-    openModal('login', 1);
-  };
+  const { handleGithubLogin, handleGoogleLogin, handleKakaoLogin } =
+    useSocialLogin();
 
   return (
     <Container>
       <KeyImg src={KEY_IMG} alt="login" />
       <Title>로그인을 해주세요</Title>
       <LoginButtons>
-        {socialLogin.map(({ name, img }, idx) => (
-          <LoginButton onClick={handleLoginButtonClick} key={idx}>
-            <LogoImg src={img} alt={name} />
-          </LoginButton>
-        ))}
+        <LoginButton onClick={handleGithubLogin}>
+          <LogoImg src={GITHUB_IMG} alt="github" />
+        </LoginButton>
+        <LoginButton onClick={handleKakaoLogin}>
+          <LogoImg src={KAKAO_IMG} alt="kakao" />
+        </LoginButton>
+        <LoginButton onClick={handleGoogleLogin}>
+          <LogoImg src={GOOGLE_IMG} alt="google" />
+        </LoginButton>
       </LoginButtons>
     </Container>
   );
@@ -75,18 +75,3 @@ const LogoImg = styled.img`
   box-shadow: 0px 0px 8px 4px rgba(0, 0, 0, 0.12);
   border-radius: 0.75rem;
 `;
-
-const socialLogin = [
-  {
-    name: 'github',
-    img: GITHUB_IMG,
-  },
-  {
-    name: 'kakao',
-    img: KAKAO_IMG,
-  },
-  {
-    name: 'google',
-    img: GOOGLE_IMG,
-  },
-];

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -18,6 +18,22 @@ const useSocialLogin = () => {
   const githubProvider = new GithubAuthProvider();
   const googleProvider = new GoogleAuthProvider();
 
+  // 유저 컬렉션에 데이터를 추가하는 함수
+  const setUserCollection = async (user: User) => {
+    await setDoc(doc(firestore, 'users', user.uid), {
+      uid: user.uid,
+      displayName: user.displayName,
+      email: user.email, // github의 경우 이메일 공개 여부에 따라 null로 할당되기도 함.
+      photoURL: user.photoURL,
+      designerStack: [],
+      developerStack: [],
+      plannerStack: [],
+      positions: [],
+      isJunior: false,
+    });
+  };
+
+  // provider를 인자로 받아 로그인을 처리하는 함수
   const signInWithPopupWithProvider = (
     provider: GithubAuthProvider | GoogleAuthProvider,
   ) => {
@@ -26,10 +42,13 @@ const useSocialLogin = () => {
         const user = result.user;
         const additionalUserInfo = getAdditionalUserInfo(result);
 
+        console.log('login sucess: ', user);
         if (additionalUserInfo?.isNewUser) {
+          // 신규 유저일 경우, 유저 컬렉션에 데이터를 추가 후 다음 페이지로 이동
           setUserCollection(user);
           openNextPage();
         } else {
+          // 기존 유저일 경우, 모달 닫기
           closeModal();
         }
       })
@@ -50,19 +69,6 @@ const useSocialLogin = () => {
     signInWithPopupWithProvider(googleProvider);
   };
 
-  const setUserCollection = async (user: User) => {
-    await setDoc(doc(firestore, 'users', user.uid), {
-      uid: user.uid,
-      displayName: user.displayName,
-      email: user.email, // github의 경우 이메일 공개 여부에 따라 null로 할당되기도 함.
-      photoURL: user.photoURL,
-      designerStack: [],
-      developerStack: [],
-      plannerStack: [],
-      positions: [],
-      isJunior: false,
-    });
-  };
   return { handleGithubLogin, handleKakaoLogin, handleGoogleLogin };
 };
 

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -1,10 +1,14 @@
+import { firestore } from 'apis/firebaseService';
 import { useGlobalModal } from 'hooks';
 import {
   GithubAuthProvider,
   getAuth,
   signInWithPopup,
   getAdditionalUserInfo,
+  GoogleAuthProvider,
+  User,
 } from 'firebase/auth';
+import { doc, setDoc } from 'firebase/firestore';
 
 const useSocialLogin = () => {
   const { openModal, closeModal } = useGlobalModal();
@@ -12,16 +16,18 @@ const useSocialLogin = () => {
 
   const auth = getAuth();
   const githubProvider = new GithubAuthProvider();
+  const googleProvider = new GoogleAuthProvider();
 
-  const handleGithubLogin = () => {
-    signInWithPopup(auth, githubProvider)
+  const signInWithPopupWithProvider = (
+    provider: GithubAuthProvider | GoogleAuthProvider,
+  ) => {
+    signInWithPopup(auth, provider)
       .then((result) => {
         const user = result.user;
-        console.log(user.uid);
-
         const additionalUserInfo = getAdditionalUserInfo(result);
 
         if (additionalUserInfo?.isNewUser) {
+          setUserCollection(user);
           openNextPage();
         } else {
           closeModal();
@@ -32,14 +38,31 @@ const useSocialLogin = () => {
       });
   };
 
+  const handleGithubLogin = () => {
+    signInWithPopupWithProvider(githubProvider);
+  };
+
   const handleKakaoLogin = () => {
     console.log('kakao login');
   };
 
   const handleGoogleLogin = () => {
-    console.log('google login');
+    signInWithPopupWithProvider(googleProvider);
   };
 
+  const setUserCollection = async (user: User) => {
+    await setDoc(doc(firestore, 'users', user.uid), {
+      uid: user.uid,
+      displayName: user.displayName,
+      email: user.email, // github의 경우 이메일 공개 여부에 따라 null로 할당되기도 함.
+      photoURL: user.photoURL,
+      designerStack: [],
+      developerStack: [],
+      plannerStack: [],
+      positions: [],
+      isJunior: false,
+    });
+  };
   return { handleGithubLogin, handleKakaoLogin, handleGoogleLogin };
 };
 

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -1,0 +1,46 @@
+import { useGlobalModal } from 'hooks';
+import {
+  GithubAuthProvider,
+  getAuth,
+  signInWithPopup,
+  getAdditionalUserInfo,
+} from 'firebase/auth';
+
+const useSocialLogin = () => {
+  const { openModal, closeModal } = useGlobalModal();
+  const openNextPage = () => openModal('login', 1);
+
+  const auth = getAuth();
+  const githubProvider = new GithubAuthProvider();
+
+  const handleGithubLogin = () => {
+    signInWithPopup(auth, githubProvider)
+      .then((result) => {
+        const user = result.user;
+        console.log(user.uid);
+
+        const additionalUserInfo = getAdditionalUserInfo(result);
+
+        if (additionalUserInfo?.isNewUser) {
+          openNextPage();
+        } else {
+          closeModal();
+        }
+      })
+      .catch((error) => {
+        console.error('error: ', error);
+      });
+  };
+
+  const handleKakaoLogin = () => {
+    console.log('kakao login');
+  };
+
+  const handleGoogleLogin = () => {
+    console.log('google login');
+  };
+
+  return { handleGithubLogin, handleKakaoLogin, handleGoogleLogin };
+};
+
+export default useSocialLogin;


### PR DESCRIPTION
## 개요 🔎

GitHub, Google 소셜 로그인 기능을 추가했습니다.
(Kakao는 추가 구현 예정)

## 작업사항 📝

- `useSocialLogin` 훅 생성
- GitHub, Google 소셜 로그인
- 로그인 완료 후 user 객체를 `로컬스토리지`에 저장

## 패키지 설치내용 📦

.