### PR TITLE
[feat] 페이지 이동 시 알림/쪽지 팝업창 닫기 기능 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,10 @@
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
 import WebContainer from './common/WebContainer';
 import PopupContainer from './popup/PopupContainer';
 import { useGlobalModal, useHeader, usePopup } from 'hooks';
 import COLORS from 'assets/styles/colors';
+import { useEffect } from 'react';
 
 interface headerTypes {
   isMain: boolean;
@@ -11,9 +12,15 @@ interface headerTypes {
 }
 
 const Header = () => {
-  const { toggleNoteBox, toggleNotificationBox } = usePopup();
+  const { closePopup, toggleNoteBox, toggleNotificationBox } = usePopup();
   const { openModal } = useGlobalModal();
   const { isMain, isLoggedIn, hideGradient, handleLogoutClick } = useHeader();
+  const location = useLocation();
+
+  // 페이지 이동 시 팝업 닫기
+  useEffect(() => {
+    closePopup();
+  }, [location.pathname]);
 
   return (
     <HeaderContainer isMain={isMain} hideGradient={hideGradient}>

--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -19,8 +19,17 @@ const usePopup = () => {
     });
   };
 
+  // 팝업 닫기 (페이지 이동 시 모든 팝업을 닫기 위한 목적)
+  const closePopup = () => {
+    setPopup({
+      isNoteOpen: false,
+      isNotificationOpen: false,
+    });
+  };
+
   return {
     popup,
+    closePopup,
     toggleNoteBox,
     toggleNotificationBox,
   };


### PR DESCRIPTION
## 개요 🔎

기존에 페이지 이동 시 알림/쪽지 팝업창이 닫히지 않아, 닫기 기능을 추가했습니다.

## 작업사항 📝

- usePopup 커스텀 훅 `closePopup` 함수 추가
- Header 컴포넌트 내에서 `pathname`이 변경되면 closePopup 호출

## 패키지 설치내용 📦

.