### PR TITLE
[PR] 지원자 목록 데이터 구조 변경

### DIFF
--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -5,11 +5,13 @@ import {
   updateDoc,
   arrayUnion,
   arrayRemove,
+  setDoc,
+  FieldValue,
 } from 'firebase/firestore';
 
 // 프로젝트 상세 조회
-export const viewProject = async (params: any) => {
-  const postDocRef = doc(firestore, 'post', params.id);
+export const viewProject = async (pid: any) => {
+  const postDocRef = doc(firestore, 'post', pid);
   const docSnap = await getDoc(postDocRef);
   return docSnap.data();
 };
@@ -43,23 +45,58 @@ export const updateMyProject = async (
     await updateDoc(docRef, { likedProjects: arrayRemove(pid) });
   }
 };
-
 export const updateApplicants = async (
   pid: string,
+  uid: string,
   displayName: string,
   profileURL: string,
   skills: string[],
   position: string,
   motive: string,
+  recruit?: boolean,
+) => {
+  // const applicants = {
+  //   displayName: displayName,
+  //   profileURL: profileURL,
+  //   skills: skills,
+  //   position: position,
+  //   motive: motive,
+  // };
+  const docRef = doc(firestore, 'post', pid);
+  // await setDoc(docRef, { applicants }, { merge: true });
+  await setDoc(
+    docRef,
+    {
+      applicants: {
+        [uid]: {
+          displayName: displayName,
+          profileURL: profileURL,
+          skills: skills,
+          position: position,
+          motive: motive,
+          recruit: recruit,
+        },
+      },
+    },
+    { merge: true },
+  );
+};
+
+export const updateParticipants = async (
+  pid: string,
+  uid: string,
+  recruit?: boolean,
 ) => {
   const docRef = doc(firestore, 'post', pid);
-  await updateDoc(docRef, {
-    applicants: arrayUnion({
-      displayName: displayName,
-      profileURL: profileURL,
-      skills: skills,
-      position: position,
-      motive: motive,
-    }),
-  });
+  await setDoc(
+    docRef,
+    {
+      applicants: {
+        [uid]: {
+          recruit: recruit,
+        },
+      },
+    },
+    { merge: true },
+  );
 };

--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -69,6 +69,7 @@ export const updateApplicants = async (
     {
       applicants: {
         [uid]: {
+          uid: uid,
           displayName: displayName,
           profileURL: profileURL,
           skills: skills,

--- a/src/components/projectDetail/ApplicantListArea.tsx
+++ b/src/components/projectDetail/ApplicantListArea.tsx
@@ -1,11 +1,24 @@
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import { useModal } from 'hooks';
+import { useEffect, useState } from 'react';
+import { allowScroll, preventScroll } from 'utils/modal';
 import InviteModal from './modals/InviteModal';
 
 const ApplicantListArea = ({ projectData, pid }: any) => {
   const { applicants } = projectData;
+  const [applicantKey, setApplicantKey] = useState('');
   const { isOpen, handleModalStateChange } = useModal(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      const prevScrollY = preventScroll();
+      return () => {
+        allowScroll(prevScrollY);
+      };
+    }
+  }, [isOpen]);
+  console.log('applicants', applicants);
 
   return (
     <ApplicantListContainer>
@@ -14,28 +27,38 @@ const ApplicantListArea = ({ projectData, pid }: any) => {
         {applicants && applicants ? (
           // applicants?.forEach((applicant: any, idx: number) => {
           Object.keys(applicants).map((key) => {
-            return (
-              <ApplicantWrap key={applicants[key]?.displayName}>
-                <ProfileImage src={applicants[key]?.profileURL} />
-                <NicknameDiv>{applicants[key]?.displayName}</NicknameDiv>
-                <PositionDiv>{applicants[key]?.position}</PositionDiv>
-                {/* 개발, 디자인, 기획 스킬 모아서 배열로 만든 후에 map돌리기 */}
-                <StackWrap>
-                  {applicants[key]?.skills.map((skill: any) => {
-                    return <StackDiv key={skill}>{skill}</StackDiv>;
-                  })}
-                </StackWrap>
-                <InviteButton onClick={handleModalStateChange}>
-                  팀원으로 초대하기
-                </InviteButton>
-                <InviteModal
-                  isOpen={isOpen}
-                  applicantData={applicants[key]}
-                  onClickEvent={handleModalStateChange}
-                  pid={pid}
-                />
-              </ApplicantWrap>
-            );
+            // console.log('test', applicants[key]);
+            if (applicants[key]?.recruit === false)
+              return (
+                <ApplicantWrap key={applicants[key]?.uid}>
+                  <ProfileImage src={applicants[key]?.profileURL} />
+                  <NicknameDiv>{applicants[key]?.displayName}</NicknameDiv>
+                  <PositionDiv>{applicants[key]?.position}</PositionDiv>
+                  {/* 개발, 디자인, 기획 스킬 모아서 배열로 만든 후에 map돌리기 */}
+                  <StackWrap>
+                    {applicants[key]?.skills.map((skill: any) => {
+                      return <StackDiv key={skill}>{skill}</StackDiv>;
+                    })}
+                  </StackWrap>
+                  <InviteButton
+                    onClick={() => {
+                      handleModalStateChange();
+                      setApplicantKey(key);
+                      // console.log('key', key);
+                    }}
+                  >
+                    팀원으로 초대하기
+                    {/* 이거 누르면 지원한 사람의 uid가 전달돼야함 */}
+                  </InviteButton>
+                  <InviteModal
+                    isOpen={isOpen}
+                    applicantData={applicants}
+                    onClickEvent={handleModalStateChange}
+                    pid={pid}
+                    applicantKey={applicantKey}
+                  />
+                </ApplicantWrap>
+              );
           })
         ) : (
           <CannotFoundApplicant>아직 지원자가 없습니다 :/</CannotFoundApplicant>

--- a/src/components/projectDetail/ApplicantListArea.tsx
+++ b/src/components/projectDetail/ApplicantListArea.tsx
@@ -3,7 +3,7 @@ import COLORS from 'assets/styles/colors';
 import { useModal } from 'hooks';
 import InviteModal from './modals/InviteModal';
 
-const ApplicantListArea = ({ projectData, userData }: any) => {
+const ApplicantListArea = ({ projectData, pid }: any) => {
   const { applicants } = projectData;
   const { isOpen, handleModalStateChange } = useModal(false);
 
@@ -32,7 +32,7 @@ const ApplicantListArea = ({ projectData, userData }: any) => {
                   isOpen={isOpen}
                   applicantData={applicants[key]}
                   onClickEvent={handleModalStateChange}
-                  //pid
+                  pid={pid}
                 />
               </ApplicantWrap>
             );

--- a/src/components/projectDetail/ApplicantListArea.tsx
+++ b/src/components/projectDetail/ApplicantListArea.tsx
@@ -6,20 +6,22 @@ import InviteModal from './modals/InviteModal';
 const ApplicantListArea = ({ projectData, userData }: any) => {
   const { applicants } = projectData;
   const { isOpen, handleModalStateChange } = useModal(false);
+
   return (
     <ApplicantListContainer>
       <ApplicantListTitle>지원자 목록</ApplicantListTitle>
       <ApplicantListContent>
-        {applicants ? (
-          applicants?.map((applicant: any) => {
+        {applicants && applicants ? (
+          // applicants?.forEach((applicant: any, idx: number) => {
+          Object.keys(applicants).map((key) => {
             return (
-              <ApplicantWrap key={applicant.displayName}>
-                <ProfileImage src={applicant.profileURL} />
-                <NicknameDiv>{applicant.displayName}</NicknameDiv>
-                <PositionDiv>{applicant.position}</PositionDiv>
+              <ApplicantWrap key={applicants[key]?.displayName}>
+                <ProfileImage src={applicants[key]?.profileURL} />
+                <NicknameDiv>{applicants[key]?.displayName}</NicknameDiv>
+                <PositionDiv>{applicants[key]?.position}</PositionDiv>
                 {/* 개발, 디자인, 기획 스킬 모아서 배열로 만든 후에 map돌리기 */}
                 <StackWrap>
-                  {applicant.skills.map((skill: any) => {
+                  {applicants[key]?.skills.map((skill: any) => {
                     return <StackDiv key={skill}>{skill}</StackDiv>;
                   })}
                 </StackWrap>
@@ -28,9 +30,9 @@ const ApplicantListArea = ({ projectData, userData }: any) => {
                 </InviteButton>
                 <InviteModal
                   isOpen={isOpen}
-                  applicantData={applicant}
+                  applicantData={applicants[key]}
                   onClickEvent={handleModalStateChange}
-                  onCloseEvent={handleModalStateChange}
+                  //pid
                 />
               </ApplicantWrap>
             );

--- a/src/components/projectDetail/ApplyButtonArea.tsx
+++ b/src/components/projectDetail/ApplyButtonArea.tsx
@@ -2,11 +2,7 @@ import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import { useState } from 'react';
 
-const ApplyButtonArea = ({
-  projectData,
-  userData,
-  onOpenButtonClickEvent,
-}: any) => {
+const ApplyButtonArea = ({ onOpenButtonClickEvent }: any) => {
   const [ApplyButtonTitle, setApplyButtonTitle] = useState('간단 지원하기');
   const handleApplyButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/components/projectDetail/WriterToShareArea.tsx
+++ b/src/components/projectDetail/WriterToShareArea.tsx
@@ -11,7 +11,7 @@ import { RiHeartAddLine, RiHeartAddFill, RiShareBoxLine } from 'react-icons/ri';
 const WriterToShareArea = ({ projectData, pid, userData }: any) => {
   const { uid, like, title, content } = projectData;
   const [countLike, setCountLike] = useState(like);
-  const [isLike, setIsLike] = useState<boolean>(); // 관심버튼 클릭시 true/false로 변경, 초기화해주면 동기화 문제 발생
+  const [isLike, setIsLike] = useState<boolean>(false); // 관심버튼 클릭시 true/false로 변경, 초기화해주면 동기화 문제 발생
   const { mutate: likeMutate } = useMutation(() => updateLike(pid, countLike));
   const { mutate: likedProjectMutate } = useMutation(() =>
     updateMyProject(uid, pid, isLike),

--- a/src/components/projectDetail/modals/ApplyModal.tsx
+++ b/src/components/projectDetail/modals/ApplyModal.tsx
@@ -29,12 +29,14 @@ const ApplyModal = ({ isOpen, message, onClickEvent }: props) => {
 
   const { mutate: applicantMutate } = useMutation(() =>
     updateApplicants(
-      '6zDpuv1af8LzMlQkmceO',
+      '6zDpuv1af8LzMlQkmceO', //pid로 수정
+      userData?.uid,
       userData?.displayName,
       userData?.photoURL,
       userData?.skills,
       positionList[clickValue].name,
       motive,
+      false,
     ),
   );
 
@@ -95,10 +97,10 @@ const ApplyModal = ({ isOpen, message, onClickEvent }: props) => {
                 return;
               } else {
                 setUsage('done');
-                setMotive('');
-                setClickValue(-1);
-                onClickEvent();
-                onAlertClickEvent();
+                setMotive(''); //지원동기 초기화
+                setClickValue(-1); //포지션 초기화
+                onClickEvent(); //모달 닫기
+                onAlertClickEvent(); //지원성공 모달 띄우기
 
                 applicantMutate(userData?.uid);
                 console.log(
@@ -265,7 +267,7 @@ const ApplyButtonContainer = styled.div`
 const AlertButton = styled.button`
   display: flex;
   flex-direction: row;
-  motive-align: center;
+  text-align: center;
   justify-content: center;
   padding: 21px 95px;
   gap: 10px;

--- a/src/components/projectDetail/modals/InviteModal.tsx
+++ b/src/components/projectDetail/modals/InviteModal.tsx
@@ -2,52 +2,37 @@ import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import Alert from 'components/common/Alert';
 import { useModal } from 'hooks';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { allowScroll, preventScroll } from 'utils/modal';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { findWithCollectionName, updateParticipants } from 'apis/postDetail';
+import { useMutation } from '@tanstack/react-query';
+import { updateParticipants } from 'apis/postDetail';
 import { useParams } from 'react-router-dom';
 interface props {
   isOpen: boolean;
   applicantData: any;
   onClickEvent: () => void;
   pid: string;
+  applicantKey: string;
 }
 
-const InviteModal = ({ isOpen, applicantData, onClickEvent, pid }: props) => {
+const InviteModal = ({
+  isOpen,
+  applicantData,
+  onClickEvent,
+  pid,
+  applicantKey,
+}: props) => {
   const { isOpen: isAlertOpen, handleModalStateChange: onAlertClickEvent } =
     useModal(false);
-
-  const [key, setKey] = useState('');
-
-  const { data: postData } = useQuery({
-    queryKey: ['6zDpuv1af8LzMlQkmceO'], //currentUser.uid로 수정
-    queryFn: () => findWithCollectionName('post', '6zDpuv1af8LzMlQkmceO'), //currentUser.uid로 수정
-  });
-  const applicants = postData?.applicants;
-  const uidArray = Object.keys(applicants).map((keys: any, idx: number) => {
-    // if (keys === 'userID') {
-    //   setKey(keys);
-    // }
-  });
-  // console.log(key);
-
+  // console.log('inviteModal', applicantData[applicantKey]);
+  // console.log('key', applicantKey);
   const { mutate: applicantMutate } = useMutation(() =>
     updateParticipants(
       pid, //pid로 수정
-      'userID', //currentUser.uid로 수정
+      applicantData[applicantKey]?.uid, //지원자uid
       true,
     ),
   );
-
-  useEffect(() => {
-    if (isOpen) {
-      const prevScrollY = preventScroll();
-      return () => {
-        allowScroll(prevScrollY);
-      };
-    }
-  }, [isOpen]);
 
   return (
     <>
@@ -61,21 +46,23 @@ const InviteModal = ({ isOpen, applicantData, onClickEvent, pid }: props) => {
       />
       <ModalContainer isOpen={isOpen}>
         <ModalWrapper>
-          <UserProfileImage src={applicantData?.profileURL} />
+          <UserProfileImage src={applicantData[applicantKey]?.profileURL} />
           <UserSkillsContainer>
-            {applicantData?.skills.map((skill: string) => {
+            {applicantData[applicantKey]?.skills.map((skill: string) => {
               return <Skills key={skill}>{skill}</Skills>;
             })}
             을/를 경험해 본 팀원이네요!
           </UserSkillsContainer>
 
-          <InviteTitle>{applicantData?.displayName} 님을</InviteTitle>
+          <InviteTitle>
+            {applicantData[applicantKey]?.displayName} 님을
+          </InviteTitle>
           <InviteTitle>팀원으로 초대할까요?</InviteTitle>
 
           <MotiveContainer>
             <MotiveTitle>지원 동기</MotiveTitle>
             <MotiveContentWrap>
-              <MotiveText>{applicantData?.motive}</MotiveText>
+              <MotiveText>{applicantData[applicantKey]?.motive}</MotiveText>
             </MotiveContentWrap>
             <MotiveButtonContainer>
               <MotiveButton onClick={onClickEvent}>아니오</MotiveButton>

--- a/src/components/projectDetail/modals/InviteModal.tsx
+++ b/src/components/projectDetail/modals/InviteModal.tsx
@@ -2,19 +2,42 @@ import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import Alert from 'components/common/Alert';
 import { useModal } from 'hooks';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { allowScroll, preventScroll } from 'utils/modal';
-
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { findWithCollectionName, updateParticipants } from 'apis/postDetail';
+import { useParams } from 'react-router-dom';
 interface props {
   isOpen: boolean;
   applicantData: any;
   onClickEvent: () => void;
-  onCloseEvent: () => void;
 }
 
 const InviteModal = ({ isOpen, applicantData, onClickEvent }: props) => {
   const { isOpen: isAlertOpen, handleModalStateChange: onAlertClickEvent } =
     useModal(false);
+
+  const [key, setKey] = useState('');
+
+  const { data: postData } = useQuery({
+    queryKey: ['6zDpuv1af8LzMlQkmceO'], //currentUser.uid로 수정
+    queryFn: () => findWithCollectionName('post', '6zDpuv1af8LzMlQkmceO'), //currentUser.uid로 수정
+  });
+  const applicants = postData?.applicants;
+  const uidArray = Object.keys(applicants).map((keys: any, idx: number) => {
+    // if (keys === 'userID') {
+    //   setKey(keys);
+    // }
+  });
+  // console.log(key);
+
+  const { mutate: applicantMutate } = useMutation(() =>
+    updateParticipants(
+      '6zDpuv1af8LzMlQkmceO', //pid로 수정
+      'userID', //currentUser.uid로 수정
+      true,
+    ),
+  );
 
   useEffect(() => {
     if (isOpen) {
@@ -33,6 +56,7 @@ const InviteModal = ({ isOpen, applicantData, onClickEvent }: props) => {
         mainMsg="팀원을 초대했어요!"
         subMsg="현재 참여한 인원에서 확인할 수 있어요!"
         usage="done"
+        page="apply"
       />
       <ModalContainer isOpen={isOpen}>
         <ModalWrapper>
@@ -58,6 +82,9 @@ const InviteModal = ({ isOpen, applicantData, onClickEvent }: props) => {
                 onClick={() => {
                   onClickEvent();
                   onAlertClickEvent();
+                  applicantMutate();
+                  //데이터 추가
+                  //데이터 삭제
                 }}
               >
                 네, 초대할게요!

--- a/src/components/projectDetail/modals/InviteModal.tsx
+++ b/src/components/projectDetail/modals/InviteModal.tsx
@@ -11,9 +11,10 @@ interface props {
   isOpen: boolean;
   applicantData: any;
   onClickEvent: () => void;
+  pid: string;
 }
 
-const InviteModal = ({ isOpen, applicantData, onClickEvent }: props) => {
+const InviteModal = ({ isOpen, applicantData, onClickEvent, pid }: props) => {
   const { isOpen: isAlertOpen, handleModalStateChange: onAlertClickEvent } =
     useModal(false);
 
@@ -33,7 +34,7 @@ const InviteModal = ({ isOpen, applicantData, onClickEvent }: props) => {
 
   const { mutate: applicantMutate } = useMutation(() =>
     updateParticipants(
-      '6zDpuv1af8LzMlQkmceO', //pid로 수정
+      pid, //pid로 수정
       'userID', //currentUser.uid로 수정
       true,
     ),

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -17,11 +17,13 @@ import ApplyModal from 'components/projectDetail/modals/ApplyModal';
 const ProjectDetailPage = () => {
   const params = useParams();
 
+  //프로젝트 데이터 조회
   const { data: projectData } = useQuery({
     queryKey: ['post', params?.id],
     queryFn: () => viewProject(params?.id),
   });
 
+  //글쓴이 조회
   const { data: userData } = useQuery({
     queryKey: ['user', projectData?.uid],
     queryFn: () => findWithCollectionName('user', projectData?.uid), //여기서 TypeError: Cannot read property of undefined 에러남 https://github.com/microsoft/vscode/issues/116219

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -62,7 +62,11 @@ const ProjectDetailPage = () => {
           />
           {/* currentUser랑 글쓴이uid랑 같으면 보이게하기 */}
 
-          <ApplicantListArea projectData={projectData} userData={userData} />
+          <ApplicantListArea
+            projectData={projectData}
+            userData={userData}
+            pid={params?.id}
+          />
         </WebContainer>
       )}
     </ProjectDetailContainer>

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -17,12 +17,12 @@ import ApplyModal from 'components/projectDetail/modals/ApplyModal';
 const ProjectDetailPage = () => {
   const params = useParams();
 
-  const { data: projectData, isLoading: projectIsLoading } = useQuery({
-    queryKey: ['post', params],
-    queryFn: () => viewProject(params),
+  const { data: projectData } = useQuery({
+    queryKey: ['post', params?.id],
+    queryFn: () => viewProject(params?.id),
   });
 
-  const { data: userData, isLoading: userIsLoading } = useQuery({
+  const { data: userData } = useQuery({
     queryKey: ['user', projectData?.uid],
     queryFn: () => findWithCollectionName('user', projectData?.uid), //여기서 TypeError: Cannot read property of undefined 에러남 https://github.com/microsoft/vscode/issues/116219
   });
@@ -61,6 +61,7 @@ const ProjectDetailPage = () => {
             onClickEvent={handleModalStateChange}
           />
           {/* currentUser랑 글쓴이uid랑 같으면 보이게하기 */}
+
           <ApplicantListArea projectData={projectData} userData={userData} />
         </WebContainer>
       )}


### PR DESCRIPTION
## 개요 🔎
#68 번째 Issue 고치는 중

## 작업사항 📝
- 데이터 구조의 이상을 느끼고 구조 변경을 시도함
[기존]
    - applicants에 map으로 데이터를 넣어 두고 지원자 목록을 관리
    - 작성자가 초대하기 버튼 클릭 시 applicants에서 데이터를 삭제하고 participants에 데이터를 삽입함
[수정]
    - applicants map에 recruit<boolean> 항목을 추가하여 지원만 했을 땐 false, 초대받았을 땐 true로 수정하도록 구현함
    - map 형식의 배열에서 map 형식의 map으로 수정하여 applicants:{[uid]: {data}}의 구조를 가짐