### PR TITLE
[PR] 프로젝트 지원, 초대 시 데이터베이스에 값 넣기

### DIFF
--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -41,6 +41,22 @@ export const updateMyProject = async (
   }
 };
 
+//프로젝트 지원 시 업데이트
+export const updateAppliedProject = async (
+  uid: string,
+  pid: string,
+  recruited: boolean,
+) => {
+  const docRef = doc(firestore, 'myprojects', uid);
+  await setDoc(
+    docRef,
+    {
+      appliedProjects: { [pid]: { recruited: recruited } },
+    },
+    { merge: true },
+  );
+};
+
 export const updateApplicants = async (
   pid: string,
   uid: string,
@@ -90,11 +106,13 @@ export const updateParticipants = async (
   );
 };
 
+//프로젝트 삭제
 export const deleteProject = async (pid: string) => {
   const docRef = doc(firestore, 'post', pid);
   await deleteDoc(docRef);
 };
 
+//모집중, 모집마감 업데이트
 export const updateRecruiting = async (pid: string, isRecruiting: any) => {
   const docRef = doc(firestore, 'post', pid);
   await updateDoc(docRef, { isRecruiting: isRecruiting });

--- a/src/components/projectDetail/ApplicantListArea.tsx
+++ b/src/components/projectDetail/ApplicantListArea.tsx
@@ -37,13 +37,11 @@ const ApplicantListArea = ({ projectData, pid }: any) => {
                   <StackContainer>
                     <StackWrap>
                       {applicants[key]?.skills.slice(0, 3).map((skill: any) => {
-                        console.log('1', skill);
                         return <StackDiv key={skill}>{skill}</StackDiv>;
                       })}
                     </StackWrap>
                     <StackWrap>
                       {applicants[key]?.skills.slice(3, 6).map((skill: any) => {
-                        console.log('2', skill);
                         return <StackDiv key={skill}>{skill}</StackDiv>;
                       })}
                     </StackWrap>
@@ -153,7 +151,6 @@ const StackDiv = styled.div`
   justify-content: center;
   padding: 0px 12px;
   gap: 10px;
-  /* width: 56px; */
   height: 32px;
   font-size: 12px;
   overflow: hidden;

--- a/src/components/projectDetail/ApplicantListArea.tsx
+++ b/src/components/projectDetail/ApplicantListArea.tsx
@@ -33,11 +33,21 @@ const ApplicantListArea = ({ projectData, pid }: any) => {
                   <ProfileImage src={applicants[key]?.profileURL} />
                   <NicknameDiv>{applicants[key]?.displayName}</NicknameDiv>
                   <PositionDiv>{applicants[key]?.position}</PositionDiv>
-                  <StackWrap>
-                    {applicants[key]?.skills.map((skill: any) => {
-                      return <StackDiv key={skill}>{skill}</StackDiv>;
-                    })}
-                  </StackWrap>
+
+                  <StackContainer>
+                    <StackWrap>
+                      {applicants[key]?.skills.slice(0, 3).map((skill: any) => {
+                        console.log('1', skill);
+                        return <StackDiv key={skill}>{skill}</StackDiv>;
+                      })}
+                    </StackWrap>
+                    <StackWrap>
+                      {applicants[key]?.skills.slice(3, 6).map((skill: any) => {
+                        console.log('2', skill);
+                        return <StackDiv key={skill}>{skill}</StackDiv>;
+                      })}
+                    </StackWrap>
+                  </StackContainer>
                   <InviteButton
                     onClick={() => {
                       handleModalStateChange();
@@ -118,14 +128,22 @@ const PositionDiv = styled.div`
   color: ${COLORS.gray800};
 `;
 
+const StackContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 248px;
+  height: 76px;
+  gap: 12px;
+`;
+
 const StackWrap = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: flex-start;
+
   gap: 8px;
-  width: 248px;
-  height: 76px;
 `;
 
 const StackDiv = styled.div`

--- a/src/components/projectDetail/ApplyButtonArea.tsx
+++ b/src/components/projectDetail/ApplyButtonArea.tsx
@@ -11,7 +11,6 @@ const ApplyButtonArea = ({ projectData, pid, onOpenButtonClickEvent }: any) => {
   const [isRecruiting, setIsRecruiting] = useState<any>(
     projectData?.isRecruiting,
   );
-  console.log('pid ', pid);
 
   const { mutate: updateRecruitingMutate } = useMutation(() =>
     updateRecruiting(pid, isRecruiting),
@@ -19,7 +18,6 @@ const ApplyButtonArea = ({ projectData, pid, onOpenButtonClickEvent }: any) => {
 
   const handleAuthorButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    console.log('1', isRecruiting);
     setIsRecruiting(!isRecruiting);
   };
 
@@ -38,10 +36,7 @@ const ApplyButtonArea = ({ projectData, pid, onOpenButtonClickEvent }: any) => {
           onOpenButtonClickEvent();
           if (uid === projectData.uid) {
             handleAuthorButtonClick(e);
-            console.log('2', isRecruiting);
             updateRecruitingMutate(pid, isRecruiting);
-
-            console.log('test');
           } else handleApplyButtonClick(e);
         }}
         backgroundColor={

--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { RiHeartAddLine, RiHeartAddFill } from 'react-icons/ri';
+import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 import React from 'react';
 import { updateLike, updateMyProject } from '../../apis/postDetail'; //여기서 에러 발생 :모듈 또는 해당 형식 선언을 찾을 수 없습니다.
 import { findWithCollectionName } from 'apis/findWithCollectionName';
@@ -50,7 +50,11 @@ const Likes = ({ pid, uid, like }: any) => {
         handleLike(event);
       }}
     >
-      {isLike ? <RiHeartAddFill /> : <RiHeartAddLine />}
+      {isLike ? (
+        <AiFillHeart size="1.5rem" color="#F14181" />
+      ) : (
+        <AiOutlineHeart size="1.5rem" color="#6B7684" />
+      )}
       관심 {countLike ?? '없음'}
     </IconButton>
   );

--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -5,8 +5,10 @@ import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 import React from 'react';
 import { updateLike, updateMyProject } from '../../apis/postDetail'; //여기서 에러 발생 :모듈 또는 해당 형식 선언을 찾을 수 없습니다.
 import { findWithCollectionName } from 'apis/findWithCollectionName';
+import { useAuth } from 'hooks';
 
-const Likes = ({ pid, uid, like }: any) => {
+const Likes = ({ pid, like }: any) => {
+  const { uid } = useAuth();
   const [countLike, setCountLike] = useState(like);
   const { mutate: likeMutate } = useMutation(() => updateLike(pid, countLike));
   const { mutate: likedProjectMutate } = useMutation(() =>

--- a/src/components/projectDetail/MemberInfoArea.tsx
+++ b/src/components/projectDetail/MemberInfoArea.tsx
@@ -28,8 +28,12 @@ const MemberInfoArea = ({ applicantsData }: any) => {
           </MemberInfoDiv>
           <MemberInfoDiv>
             <PositionDiv>개발</PositionDiv>
+
             {data.map((key) => {
-              if (applicantsData[key].position === '프론트엔드' || '백엔드')
+              if (
+                applicantsData[key].position === '프론트엔드' ||
+                applicantsData[key].position === '백엔드'
+              )
                 return (
                   <MemberProfileImg
                     key={key}

--- a/src/components/projectDetail/WriterToShareArea.tsx
+++ b/src/components/projectDetail/WriterToShareArea.tsx
@@ -15,7 +15,7 @@ const WriterToShareArea = ({ projectData, pid, userData }: any) => {
       </WriterWrapper>
       <IconWrapper>
         <Views pid={pid} view={view} />
-        <Likes pid={pid} uid={uid} like={like} />
+        <Likes pid={pid} like={like} />
         <Share title={title} content={content} />
       </IconWrapper>
     </WriterToShareContainer>

--- a/src/components/projectDetail/WriterToShareArea.tsx
+++ b/src/components/projectDetail/WriterToShareArea.tsx
@@ -46,7 +46,6 @@ const WriterProfileImg = styled.img`
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
-  background-color: #aaaaaa; //영역 표시용 임시 색상
 `;
 
 const WriterNickname = styled.p`

--- a/src/components/projectDetail/modals/ApplyModal.tsx
+++ b/src/components/projectDetail/modals/ApplyModal.tsx
@@ -52,14 +52,33 @@ const ApplyModal = ({ isOpen, message, onClickEvent, pid }: props) => {
 
   //디자인스택, 개발스택, 기획 스택 합쳐서 중복제거
   //Todo 포지션 선택에 따라 스택 보여주기
-  const skills = Array.from(
-    new Set(
-      userData?.designerStack.concat(
-        userData?.developerStack,
-        userData?.plannerStack,
-      ),
-    ),
-  );
+  // const skills = Array.from(
+  //   new Set(
+  //     userData?.designerStack.concat(
+  //       userData?.developerStack,
+  //       userData?.plannerStack,
+  //     ),
+  //   ),
+  // );
+  let skills: string[] = [];
+  switch (clickValue) {
+    case 0: //기획
+      skills = userData?.plannerStack;
+      break;
+    case 1: //디자인
+      skills = userData?.designerStack;
+      break;
+    case 2: //프론트엔드
+      skills = userData?.developerStack;
+      break;
+    case 3: //백엔드
+      skills = userData?.developerStack;
+      break;
+
+    default:
+      skills = [];
+      break;
+  }
 
   const { mutate: applicantMutate } = useMutation(() =>
     updateApplicants(

--- a/src/components/projectDetail/modals/InviteModal.tsx
+++ b/src/components/projectDetail/modals/InviteModal.tsx
@@ -2,11 +2,9 @@ import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import Alert from 'components/common/Alert';
 import { useModal } from 'hooks';
-import { useEffect } from 'react';
-import { allowScroll, preventScroll } from 'utils/modal';
 import { useMutation } from '@tanstack/react-query';
 import { updateAppliedProject, updateParticipants } from 'apis/postDetail';
-import { useParams } from 'react-router-dom';
+
 interface props {
   isOpen: boolean;
   applicantData: any;
@@ -51,9 +49,11 @@ const InviteModal = ({
         <ModalWrapper>
           <UserProfileImage src={applicantData[applicantKey]?.profileURL} />
           <UserSkillsContainer>
-            {applicantData[applicantKey]?.skills.map((skill: string) => {
-              return <Skills key={skill}>{skill}</Skills>;
-            })}
+            {applicantData[applicantKey]?.skills
+              .slice(0, 5)
+              .map((skill: string) => {
+                return <Skills key={skill}>{skill}</Skills>;
+              })}
             을/를 경험해 본 팀원이네요!
           </UserSkillsContainer>
 

--- a/src/components/projectDetail/modals/InviteModal.tsx
+++ b/src/components/projectDetail/modals/InviteModal.tsx
@@ -5,7 +5,7 @@ import { useModal } from 'hooks';
 import { useEffect } from 'react';
 import { allowScroll, preventScroll } from 'utils/modal';
 import { useMutation } from '@tanstack/react-query';
-import { updateParticipants } from 'apis/postDetail';
+import { updateAppliedProject, updateParticipants } from 'apis/postDetail';
 import { useParams } from 'react-router-dom';
 interface props {
   isOpen: boolean;
@@ -31,6 +31,10 @@ const InviteModal = ({
       applicantData[applicantKey]?.uid, //지원자uid
       true,
     ),
+  );
+
+  const { mutate: invitedProjectMutate } = useMutation(() =>
+    updateAppliedProject(applicantData[applicantKey]?.uid, pid, true),
   );
 
   return (
@@ -70,8 +74,8 @@ const InviteModal = ({
                   onClickEvent();
                   onAlertClickEvent();
                   applicantMutate();
-                  //데이터 추가
-                  //데이터 삭제
+                  invitedProjectMutate();
+                  //applicants 데이터 변경
                 }}
               >
                 네, 초대할게요!

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -35,7 +35,6 @@ const ProjectDetailPage = () => {
   //projectData?.uid 가 현재 uid랑 같은지 판별하고 같으면 수정하기 버튼 display, 지원하기 버튼 -> 마감하기 버튼으로 변경, 지원자 목록 보여주기
   //지원하기 버튼 클릭시 지원자 목록에 uid 추가
   //현재 참여중인 인원, 지원한 인원 uid로 모두 user테이블 조회해서 닉네임, 프로필 사진 가져오기???
-  console.log(params);
   return (
     <ProjectDetailContainer>
       {projectData && userData && (


### PR DESCRIPTION
## 개요 🔎
Fixes #111 


## 작업사항 📝
- 지원 완료 시 myproject 컬렉션의 appliedProjects에 데이터가 들어간다.
- 초대 완료 시 myprojcet 컬렉션의 appliedProjects의 recruited의 데이터가 false에서 true로 바뀐다.
- 지원자 목록에서 스택 두 줄로 변경
- 지원하기 모달에서 보여주는 스택 개수 제한
- 하트 아이콘 변경
- 좋아요 로직 수정

@yujleee 혹시 appliedProjects 이 부분 map 돌려보시고 문제가 되면 얘기해주세요!!

데이터 구조:  appliedProjects: {[pid]: recruited}}
recruited<boolean> false면 초대 전 true면 초대완료
![image](https://user-images.githubusercontent.com/88365786/219362524-bffa385f-cf1f-49a0-93cc-7ad47110ef5a.png)
