### PR TITLE
[feat] 프로젝트 상세 보기 모집 & 지원 기준확인 및 Alert 생성

### DIFF
--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -118,3 +118,15 @@ export const updateRecruiting = async (pid: string, isRecruiting: any) => {
   await updateDoc(docRef, { isRecruiting: isRecruiting });
   console.log('isRecruit', isRecruiting);
 };
+
+// 지원 여부 확인
+export const firebaseGetIsApplicantRequest = async (pid: any, uid: string) => {
+  const postDocRef = doc(firestore, 'post', pid);
+  const docSnap = await getDoc(postDocRef);
+  const applicants = docSnap.data()?.applicants;
+  if (applicants) {
+    return applicants[uid] ? true : false;
+  } else {
+    return false;
+  }
+};

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -77,7 +77,7 @@ const ContantCardImgContainer = styled.img`
   width: 380px;
   height: 214px;
   background: #ced3db;
-  background-size: cover;
+  object-fit: cover;
   border-radius: 6px 6px 0px 0px;
 `;
 const ContantCardContentsContainer = styled.div`

--- a/src/components/projectDetail/ApplyButtonArea.tsx
+++ b/src/components/projectDetail/ApplyButtonArea.tsx
@@ -1,52 +1,36 @@
 import styled from '@emotion/styled';
-import { useMutation } from '@tanstack/react-query';
-import { updateRecruiting } from 'apis/postDetail';
 import COLORS from 'assets/styles/colors';
 import { useAuth } from 'hooks';
-import { useState } from 'react';
 
-const ApplyButtonArea = ({ projectData, pid, onOpenButtonClickEvent }: any) => {
+const ApplyButtonArea = ({
+  isApplicant,
+  projectData,
+  onApplyModalStateChangeEvent,
+  onCloseModalStateChangeEvent,
+}: any) => {
   const { uid } = useAuth();
-  const [ButtonTitle, setButtonTitle] = useState('');
-  const [isRecruiting, setIsRecruiting] = useState<any>(
-    projectData?.isRecruiting,
-  );
+  const { isRecruiting } = projectData;
 
-  const { mutate: updateRecruitingMutate } = useMutation(() =>
-    updateRecruiting(pid, isRecruiting),
-  );
-
-  const handleAuthorButtonClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsRecruiting(!isRecruiting);
-  };
-
-  const handleApplyButtonClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-
-    //TODO: myprojects에서 지원한 프로젝트인지 확인 후 지원하기/지원취소하기 버튼 변경
-    setButtonTitle(
-      ButtonTitle === '간단 지원하기' ? '지원 취소하기' : '간단 지원하기',
-    );
-  };
   return (
     <ButtonWrapper>
-      <ApplyButton
-        onClick={(e) => {
-          onOpenButtonClickEvent();
-          if (uid === projectData.uid) {
-            handleAuthorButtonClick(e);
-            updateRecruitingMutate(pid, isRecruiting);
-          } else handleApplyButtonClick(e);
-        }}
-        backgroundColor={
-          ButtonTitle === '간단 지원하기' || '지원공고 마감하기'
-            ? `${COLORS.violetB400}`
-            : '#464646' //색상표에 없는데 사용되고 있음. 문의하기
-        }
-      >
-        {uid === projectData.uid ? '지원공고 마감하기' : '간단 지원하기'}
-      </ApplyButton>
+      {projectData.uid === uid ? (
+        <ApplyButton
+          onClick={onCloseModalStateChangeEvent}
+          disabled={!isRecruiting}
+        >
+          {isRecruiting ? '지원공고 마감하기' : '마감 완료'}
+        </ApplyButton>
+      ) : (
+        <ApplyButton
+          onClick={() => {
+            isApplicant
+              ? onCloseModalStateChangeEvent()
+              : onApplyModalStateChangeEvent();
+          }}
+        >
+          {isApplicant ? '지원취소' : '간단 지원하기'}
+        </ApplyButton>
+      )}
     </ButtonWrapper>
   );
 };
@@ -60,11 +44,14 @@ const ButtonWrapper = styled.div`
   margin-top: 3.5rem;
 `;
 
-const ApplyButton = styled.button<{ backgroundColor: string }>`
+const ApplyButton = styled.button`
   width: 32.5625rem;
   height: 5.5rem;
-  background-color: ${(props) => props.backgroundColor};
+  background-color: ${COLORS.violetB400};
   border-radius: 2.25rem;
   font-size: 1.75rem;
   color: ${COLORS.white};
+  :disabled {
+    background-color: ${COLORS.gray200};
+  }
 `;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -7,9 +7,19 @@ const useModal = (initialValue: boolean) => {
     setIsOpen((prev: boolean) => !prev);
   }, [setIsOpen]);
 
+  const handleModalOpenChagne = useCallback(() => {
+    setIsOpen(true);
+  }, [setIsOpen]);
+
+  const handleModalCloseChagne = useCallback(() => {
+    setIsOpen(false);
+  }, [setIsOpen]);
+
   return {
     isOpen,
     handleModalStateChange,
+    handleModalOpenChagne,
+    handleModalCloseChagne,
   };
 };
 

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 import WebContainer from '../components/common/WebContainer';
 import { useParams } from 'react-router-dom';
-import { viewProject } from 'apis/postDetail';
+import {
+  firebaseGetIsApplicantRequest,
+  updateRecruiting,
+  viewProject,
+} from 'apis/postDetail';
 import { findWithCollectionName } from 'apis/findWithCollectionName';
 import TitleThumbnailArea from 'components/projectDetail/TitleThumbnailArea';
 import WriterToShareArea from 'components/projectDetail/WriterToShareArea';
@@ -11,9 +15,10 @@ import ContentArea from 'components/projectDetail/ContentArea';
 import ApplyButtonArea from 'components/projectDetail/ApplyButtonArea';
 import ApplicantListArea from 'components/projectDetail/ApplicantListArea';
 import COLORS from 'assets/styles/colors';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useAuth, useModal } from 'hooks';
 import ApplyModal from 'components/projectDetail/modals/ApplyModal';
+import ConfirmAlert from 'components/common/ConfirmAlert';
 
 const ProjectDetailPage = () => {
   const params = useParams();
@@ -23,6 +28,7 @@ const ProjectDetailPage = () => {
     queryKey: ['post', params?.id],
     queryFn: () => viewProject(params?.id),
   });
+
   const { uid } = useAuth();
   //글쓴이 조회
   const { data: userData } = useQuery({
@@ -30,14 +36,39 @@ const ProjectDetailPage = () => {
     queryFn: () => findWithCollectionName('users', projectData?.uid), //여기서 TypeError: Cannot read property of undefined 에러남 https://github.com/microsoft/vscode/issues/116219
   });
 
-  const { isOpen, handleModalStateChange } = useModal(false);
+  // 현재 유저가 프로젝트 지원자 인가 조회
+  const { data: isApplicant } = useQuery({
+    queryKey: ['post', projectData?.applicants],
+    queryFn: () => firebaseGetIsApplicantRequest(params?.id, uid),
+  });
+
+  const { mutate: updateRecruitingMutate } = useMutation(() =>
+    updateRecruiting(params?.id as string, false),
+  );
+
+  // 마감하기 버튼 이벤트 핸들러
+  const handleAuthorButtonClick = () => {
+    updateRecruitingMutate(params?.id as any, false as any);
+    handleCloseModalCloseChagne();
+  };
+
+  const {
+    isOpen: isApply,
+    handleModalOpenChagne: handleApplyModalOpenChagne,
+    handleModalCloseChagne: handleApplyModalCloseChagne,
+  } = useModal(false);
+  const {
+    isOpen: isClose,
+    handleModalOpenChagne: handleCloseModalOpenChagne,
+    handleModalCloseChagne: handleCloseModalCloseChagne,
+  } = useModal(false);
 
   //projectData?.uid 가 현재 uid랑 같은지 판별하고 같으면 수정하기 버튼 display, 지원하기 버튼 -> 마감하기 버튼으로 변경, 지원자 목록 보여주기
   //지원하기 버튼 클릭시 지원자 목록에 uid 추가
   //현재 참여중인 인원, 지원한 인원 uid로 모두 user테이블 조회해서 닉네임, 프로필 사진 가져오기???
   return (
     <ProjectDetailContainer>
-      {projectData && userData && (
+      {projectData && (
         <WebContainer>
           <ProjectDetailWrapper>
             <TitleThumbnailArea projectData={projectData} pid={params?.id} />
@@ -53,15 +84,36 @@ const ProjectDetailPage = () => {
             <ContentArea projectData={projectData} />
           </ProjectDetailWrapper>
           <ApplyButtonArea
-            projectData={projectData}
             pid={params?.id}
-            onOpenButtonClickEvent={handleModalStateChange}
+            isApplicant={isApplicant}
+            projectData={projectData}
+            onApplyModalStateChangeEvent={handleApplyModalOpenChagne}
+            onCloseModalStateChangeEvent={handleCloseModalOpenChagne}
           />
           <ApplyModal
-            isOpen={isOpen}
+            isOpen={isApply}
             message="프로젝트를 지원해볼까요?"
-            onClickEvent={handleModalStateChange}
+            onClickEvent={handleApplyModalCloseChagne}
             pid={params.id as string}
+          />
+          <ConfirmAlert
+            isOpen={isClose}
+            message={
+              isApplicant
+                ? '지원을 취소하시겠습니까?'
+                : '지원공고를 마감할까요?'
+            }
+            subMessage={
+              isApplicant
+                ? '정말 취소 하실건지 확인해주세요!'
+                : '팀원이 모두 모집되었는지 한 번 더 확인해주세요!'
+            }
+            onClickEvent={() => {
+              isApplicant
+                ? handleCloseModalCloseChagne()
+                : handleAuthorButtonClick();
+            }}
+            onCloseEvent={handleCloseModalCloseChagne}
           />
           {/* currentUser랑 글쓴이uid랑 같으면 보이게하기 */}
           {projectData?.uid === uid && (


### PR DESCRIPTION
## 개요 :mag_right:

- 프로젝트 상세 보기 비작성자일 경우 지원 신청 / 지원 취소 구분
- 프로젝트 상세 보기 작성자일 경우 모집완료 / 모집마감 구분
- 각각에 상황에 따라 Alert 생성

## 작업사항 :pencil:

- Firebase 프로젝트 지원자인지 확인 여부 로직 작성
- useModal 여러개일 경우 ! 인자 에러나서 True False 고정 값 함수 생성
- 지원 & 마감 데이터 얻어와서 각각 화면에 맞는 Alert 타이틀과 메시지 보여주기
- 프로젝트 찾기 썸네일 이미지 fit으로 수정

## 패키지 설치내용 :package: