### PR TITLE
[fix] 유저 정보 수정 후 버튼 클릭 시의 유효성 검사 확인 추가

### DIFF
--- a/src/components/mypage/MyPageInfo.tsx
+++ b/src/components/mypage/MyPageInfo.tsx
@@ -1,14 +1,11 @@
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { useMutation } from '@tanstack/react-query';
-import { useModal, useUpdateProfile, useProfileImage } from 'hooks';
+import { useModal } from 'hooks';
 import styled from '@emotion/styled';
 import { mypageInfoButtonActiveState, userInfoState } from '../../recoil/atoms';
-import MyPageProfileImage from './MyPageProfileImage';
-import PositionCheckBox from './PositionCheckBox';
+import UserInfoTop from './UserInfoTop';
 import SkillList from './SkillList';
-import TextInput from './TextInput';
-import Careers from './Careers';
 import ConfirmAlert from 'components/common/ConfirmAlert';
 import { designs, develops, products } from 'utils/skills';
 import COLORS from 'assets/styles/colors';
@@ -20,16 +17,11 @@ interface MypageInfoProps {
 }
 
 const MyPageInfo = ({ user, uid }: MypageInfoProps) => {
-  const { handleInputChange, validationMessage, contactValidationMessage } =
-    useUpdateProfile();
   const [userInfo, setUserInfo] = useRecoilState(userInfoState);
   const [activeInfoBtn, setActiveInfoBtn] = useRecoilState<boolean>(
     mypageInfoButtonActiveState,
   );
   const { isOpen, handleModalStateChange } = useModal(false);
-  const { profileImg, handleProfileImageChange, handleProfileImageDelete } =
-    useProfileImage(uid, userInfo.photoURL);
-
   const { mutate: updateUserInfoMutate } = useMutation(() =>
     updateUserInfoData(uid, userInfo),
   );
@@ -59,44 +51,7 @@ const MyPageInfo = ({ user, uid }: MypageInfoProps) => {
 
   return (
     <MyPageTopContainer>
-      <MypageInfoTopContainer>
-        <MyPageProfileImage
-          profileImg={profileImg}
-          onChange={handleProfileImageChange}
-          onDelete={handleProfileImageDelete}
-          uid={uid}
-        />
-        <InfoWrapper>
-          <InfoItemDiv>
-            <InfoTitle htmlFor="nickname">닉네임</InfoTitle>
-            <TextInput
-              name="displayName"
-              value={userInfo.displayName}
-              onChangeValue={handleInputChange}
-              validationMessage={validationMessage}
-            />
-          </InfoItemDiv>
-          <InfoItemDiv>
-            <InfoTitle htmlFor="contact">연락처</InfoTitle>
-            <TextInput
-              name="email"
-              value={userInfo.email ?? ''}
-              onChangeValue={handleInputChange}
-              placeholder="연락처로 쓰일 이메일을 입력해주세요."
-              validationMessage={contactValidationMessage}
-              isEmail={true}
-            />
-          </InfoItemDiv>
-          <InfoItemDiv>
-            <InfoTitle>경력</InfoTitle>
-            <Careers isJunior={userInfo.isJunior} />
-          </InfoItemDiv>
-          <InfoItemDiv>
-            <InfoTitle>포지션</InfoTitle>
-            <PositionCheckBox positions={userInfo.positions} />
-          </InfoItemDiv>
-        </InfoWrapper>
-      </MypageInfoTopContainer>
+      <UserInfoTop /> {/* 유저 개인 정보  */}
       <MyPageSkillsWrapper>
         <MyPageSkillsTitle>기술스택</MyPageSkillsTitle>
         <MypageSkillBox>
@@ -117,7 +72,6 @@ const MyPageInfo = ({ user, uid }: MypageInfoProps) => {
           />
         </MypageSkillBox>
       </MyPageSkillsWrapper>
-
       <InfoEditConfirmWrapper>
         <InfoEditConfirmBtn
           isActive={activeInfoBtn}
@@ -140,30 +94,6 @@ const MyPageInfo = ({ user, uid }: MypageInfoProps) => {
 export default MyPageInfo;
 
 const MyPageTopContainer = styled.div``;
-
-const MypageInfoTopContainer = styled.div`
-  padding-top: 3.125rem;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-`;
-
-const InfoWrapper = styled.div``;
-
-const InfoItemDiv = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 1.625rem;
-`;
-
-const InfoTitle = styled.label`
-  display: block;
-  width: 4rem;
-  font-size: 1.25rem;
-  color: #383838;
-  text-align: right;
-  margin-right: 3rem;
-`;
 
 const MyPageSkillsWrapper = styled.div`
   margin-top: 3.125rem;

--- a/src/components/mypage/UserInfoTop.tsx
+++ b/src/components/mypage/UserInfoTop.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+import { useAuth, useProfileImage, useUpdateProfile } from 'hooks';
+import { useRecoilValue } from 'recoil';
+import { userInfoState } from '../../recoil/atoms';
+import Careers from './Careers';
+import MyPageProfileImage from './MyPageProfileImage';
+import PositionCheckBox from './PositionCheckBox';
+import TextInput from './TextInput';
+
+const UserInfoTop = () => {
+  const userInfo = useRecoilValue(userInfoState);
+  const { handleInputChange, validationMessage, contactValidationMessage } =
+    useUpdateProfile();
+  const { uid } = useAuth();
+  const { profileImg, handleProfileImageChange, handleProfileImageDelete } =
+    useProfileImage(uid, userInfo.photoURL);
+
+  return (
+    <MypageInfoTopContainer>
+      <MyPageProfileImage
+        profileImg={profileImg}
+        onChange={handleProfileImageChange}
+        onDelete={handleProfileImageDelete}
+        uid={uid}
+      />
+      <InfoWrapper>
+        <InfoItemDiv>
+          <InfoTitle htmlFor="nickname">닉네임</InfoTitle>
+          <TextInput
+            name="displayName"
+            value={userInfo.displayName}
+            onChangeValue={handleInputChange}
+            validationMessage={validationMessage}
+          />
+        </InfoItemDiv>
+        <InfoItemDiv>
+          <InfoTitle htmlFor="contact">연락처</InfoTitle>
+          <TextInput
+            name="email"
+            value={userInfo.email ?? ''}
+            onChangeValue={handleInputChange}
+            placeholder="연락처로 쓰일 이메일을 입력해주세요."
+            validationMessage={contactValidationMessage}
+            isEmail={true}
+          />
+        </InfoItemDiv>
+        <InfoItemDiv>
+          <InfoTitle>경력</InfoTitle>
+          <Careers isJunior={userInfo.isJunior} />
+        </InfoItemDiv>
+        <InfoItemDiv>
+          <InfoTitle>포지션</InfoTitle>
+          <PositionCheckBox positions={userInfo.positions} />
+        </InfoItemDiv>
+      </InfoWrapper>
+    </MypageInfoTopContainer>
+  );
+};
+
+export default UserInfoTop;
+
+const MypageInfoTopContainer = styled.div`
+  padding-top: 3.125rem;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const InfoWrapper = styled.div``;
+
+const InfoItemDiv = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.625rem;
+`;
+
+const InfoTitle = styled.label`
+  display: block;
+  width: 4rem;
+  font-size: 1.25rem;
+  color: #383838;
+  text-align: right;
+  margin-right: 3rem;
+`;

--- a/src/hooks/useUpdateProfile.ts
+++ b/src/hooks/useUpdateProfile.ts
@@ -6,6 +6,7 @@ import { contactValidation, nicknameValidation } from 'utils/validation';
 const useUpdateProfile = () => {
   const setUserInfo = useSetRecoilState<UserInfo>(userInfoState);
   const setActiveInfoBtn = useSetRecoilState(mypageInfoButtonActiveState);
+
   const [validationMessage, setValidationMessage] = useState<string>('');
   const [contactValidationMessage, setContactValidationMessage] =
     useState<string>('');
@@ -20,31 +21,21 @@ const useUpdateProfile = () => {
           ? nicknameValidation(value)
           : contactValidation(value);
 
-      console.log('isValidate', isValidate);
-
-      if (name === 'displayName' && !isValidate) {
-        if (value.length < 2) {
-          setValidationMessage('닉네임은 2자 이상이어야 합니다.');
-          return;
+      if (!isValidate) {
+        if (name === 'displayName') {
+          value.length < 2
+            ? setValidationMessage('닉네임은 2자 이상이어야 합니다.')
+            : setValidationMessage('닉네임은 7자 이하여야 합니다.');
         } else {
-          setValidationMessage('닉네임은 7자 이하여야 합니다.');
-          return;
+          value === ''
+            ? setContactValidationMessage('이메일을 입력해주세요.')
+            : setContactValidationMessage('이메일을 올바르게 입력해주세요.');
         }
+      } else {
+        setValidationMessage('');
+        setContactValidationMessage('');
+        setActiveInfoBtn(true);
       }
-
-      if (name === 'email' && !isValidate) {
-        if (value === '') {
-          setContactValidationMessage('이메일을 입력해주세요.');
-          return;
-        } else {
-          setContactValidationMessage('이메일을 올바르게 입력해주세요.');
-          return;
-        }
-      }
-
-      setValidationMessage('');
-      setContactValidationMessage('');
-      setActiveInfoBtn(true);
 
       setUserInfo((prevState) => {
         return { ...prevState, [name]: value };

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -6,28 +6,9 @@ import WebContainer from 'components/common/WebContainer';
 import MyPageInfo from 'components/mypage/MyPageInfo';
 import ProjectList from 'components/common/myProjectList/ProjectList';
 import LeftTab from 'components/mypage/LeftTab';
-import { getUserInfoData, getUserProjectList } from 'apis/mypageUsers';
-
 import ProjectsTab from 'components/mypage/ProjectsTab';
+import { getUserInfoData, getUserProjectList } from 'apis/mypageUsers';
 import { staleTime } from 'utils/staleTime';
-
-export interface Project {
-  id: string;
-  title: string;
-  thumbnail: string;
-  skills: string[];
-  participants: Participants[];
-}
-export interface Participants {
-  type: string;
-  members: Member[];
-}
-
-interface Member {
-  uid: string;
-  profile: string;
-  skill: string;
-}
 
 const MyPage = () => {
   const [activeTab, setActiveTab] = useState('개인정보');


### PR DESCRIPTION
## 개요 🔎

Closes #158 

유저 정보 수정 후 버튼 클릭 시의 유효성 검사 확인 로직이 누락되어 추가했습니다.
이메일 같은 경우는 null 값이 허용되기 때문에 (깃허브 가입 시 null인 경우 있음)
빈 값일 경우의 처리가 어려워서 유효한 이메일인지 확인하도록 했습니다.

## 작업사항 📝

* 아무것도 수정하지 않았다면 수정버튼 disabled 처리
* 완료 버튼 클릭 시 닉네임 / 이메일 / 포지션 유효성 검사에 따라 toast 팝업 보여주기

## 패키지 설치내용 📦

.