### PR TITLE
[feat] 로그인 권한 예외처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { Global } from '@emotion/react';
 import { authService } from 'apis/firebaseService';
 import reset from 'assets/styles/globalStyled';
-import Router from 'routes/Router';
+import { RouterProvider } from 'react-router-dom';
+import router from 'routes/Router';
 
 function App() {
   authService.onAuthStateChanged((user) => {
@@ -21,7 +22,7 @@ function App() {
   return (
     <>
       <Global styles={reset} />
-      <Router />
+      <RouterProvider router={router} />
     </>
   );
 }

--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -33,6 +33,7 @@ export const updateMyProject = async (
   pid: string,
   isLiked: boolean,
 ) => {
+  if (!uid) return;
   const docRef = doc(firestore, 'myprojects', uid);
   if (isLiked === true) {
     await updateDoc(docRef, { likedProjects: arrayUnion(pid) });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -54,9 +54,22 @@ const Header = () => {
           </LogoBoxH1>
           <Nav>
             <NavListUl>
-              <NavItemLi>
-                <NavItemLink to={'/project/write'}>새 글 쓰기</NavItemLink>
+              <NavItemLi onClick={() => !isLoggedIn && openModal('login', 0)}>
+                {isLoggedIn ? (
+                  <NavItemLink to={'/project/write'}>새 글 쓰기</NavItemLink>
+                ) : (
+                  '새 글 쓰기'
+                )}
               </NavItemLi>
+              {/* {isLoggedIn ? (
+                <NavItemLi>
+                  <NavItemLink to={'/project/write'}>새 글 쓰기</NavItemLink>
+                </NavItemLi>
+              ) : (
+                <NavItemLi onClick={() => openModal('login', 0)}>
+                  새 글 쓰기
+                </NavItemLi>
+              )} */}
               <NavItemLi>
                 <NavItemLink to={'/findproject'}>팀원찾기</NavItemLink>
               </NavItemLi>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,11 +33,13 @@ const Header = () => {
         queryKey: ['inbox', uid],
         queryFn: getInboxNotes,
         staleTime: staleTime.inboxNotes,
+        enabled: !!uid,
       },
       {
         queryKey: ['notifications', uid],
         queryFn: getNotifications,
         staleTime: staleTime.notifications,
+        enabled: !!uid,
       },
     ],
   });

--- a/src/components/projectDetail/ApplyButtonArea.tsx
+++ b/src/components/projectDetail/ApplyButtonArea.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
-import { useAuth } from 'hooks';
+import { useAuth, useGlobalModal } from 'hooks';
 
 const ApplyButtonArea = ({
   isApplicant,
@@ -9,6 +9,7 @@ const ApplyButtonArea = ({
   onCloseModalStateChangeEvent,
 }: any) => {
   const { uid } = useAuth();
+  const { openModal } = useGlobalModal();
   const { isRecruiting, applicants } = projectData;
   return (
     <ButtonWrapper>
@@ -28,6 +29,10 @@ const ApplyButtonArea = ({
           ) : (
             <ApplyButton
               onClick={() => {
+                if (!uid) {
+                  openModal('login', 0);
+                  return;
+                }
                 isApplicant //지원하고 초대는 안된 상태
                   ? onCloseModalStateChangeEvent()
                   : onApplyModalStateChangeEvent();

--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -48,6 +48,7 @@ const Likes = ({ pid, like }: any) => {
   return (
     <IconButton
       onClick={(event) => {
+        if (!uid) return;
         handleLike(event);
       }}
     >

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,31 +1,33 @@
 import useAuth from './useAuth';
+import useEdtiBoard from './useEditBoard';
+import useFindProject from './useFindProject';
+import useGlobalModal from './useGlobalModal';
+import useHeader from './useHeader';
+import useIsLogin from './useIsLogin';
 import useModal from './useModal';
 import useNote from './useNote';
 import useNotification from './useNotification';
 import usePopup from './usePopup';
-import useGlobalModal from './useGlobalModal';
-import useWrite from './useWrite';
-import useEdtiBoard from './useEditBoard';
 import useProfileImage from './useProfileImage';
-import useUpdateProfile from './useUpdateProfile';
-import useHeader from './useHeader';
-import useFindProject from './useFindProject';
-import useToastPopup from './useToastPopup';
 import useProjectList from './useProjectList';
+import useToastPopup from './useToastPopup';
+import useUpdateProfile from './useUpdateProfile';
+import useWrite from './useWrite';
 
 export {
   useAuth,
+  useEdtiBoard,
+  useFindProject,
+  useGlobalModal,
+  useHeader,
+  useIsLogin,
   useModal,
   useNote,
   useNotification,
   usePopup,
-  useGlobalModal,
-  useWrite,
-  useEdtiBoard,
   useProfileImage,
-  useUpdateProfile,
-  useHeader,
-  useFindProject,
-  useToastPopup,
   useProjectList,
+  useToastPopup,
+  useUpdateProfile,
+  useWrite,
 };

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -23,7 +23,9 @@ const useFindProject = () => {
       lastVisible,
       setLastVisible,
     );
-    firebaseFindMyInterestRequset(uid, setLikedProjects);
+    if (uid) {
+      firebaseFindMyInterestRequset(uid, setLikedProjects);
+    }
 
     window.onbeforeunload = () => {
       window.scrollTo(0, 0);

--- a/src/hooks/useIsLogin.ts
+++ b/src/hooks/useIsLogin.ts
@@ -1,0 +1,10 @@
+import useAuth from './useAuth';
+
+const useIsLogin = () => {
+  const user = useAuth();
+  if (!user) return false;
+  if (Object.keys(user).length === 0) return false;
+  return true;
+};
+
+export default useIsLogin;

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -19,7 +19,7 @@ const PublicProfilePage = () => {
   const { uid } = useAuth(); //보내는 사람 id (현재 로그인한 유저)
   const { activeProjectTab, handleProjectTabClick, setActiveProjectTab } =
     useProjectList();
-  const { openModalWithData } = useGlobalModal();
+  const { openModalWithData, openModal } = useGlobalModal();
 
   const { data: userInfoData }: any = useQuery({
     queryKey: ['users', id],
@@ -79,7 +79,15 @@ const PublicProfilePage = () => {
                   )}
                 </UserInformationDiv>
                 {userInfoData?.uid !== uid && (
-                  <MessageSendButton onClick={handleSendNoteButtonClick}>
+                  <MessageSendButton
+                    onClick={() => {
+                      if (!uid) {
+                        openModal('login', 0);
+                        return;
+                      }
+                      handleSendNoteButtonClick();
+                    }}
+                  >
                     쪽지보내기
                   </MessageSendButton>
                 )}

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -9,11 +9,11 @@ import LoadingPage from './LoadingPage';
 export default function Root() {
   return (
     <>
-      <ScrollToTop />
-      <ScrollToTopButton />
       <Header />
-      <ModalContainer />
       <Suspense fallback={<LoadingPage />}>
+        <ScrollToTop />
+        <ScrollToTopButton />
+        <ModalContainer />
         <Outlet />
       </Suspense>
     </>

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -2,11 +2,20 @@ import ModalContainer from 'components/common/modal/ModalContainer';
 import ScrollToTop from 'components/common/scrollToTop';
 import Header from 'components/Header';
 import ScrollToTopButton from 'components/ScrollToTopButton';
-import { Suspense } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useGlobalModal } from 'hooks';
+import { Suspense, useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import LoadingPage from './LoadingPage';
 
 export default function Root() {
+  const { closeModal } = useGlobalModal();
+  const location = useLocation();
+
+  // 페이지 이동 시 팝업 닫기
+  useEffect(() => {
+    closeModal();
+  }, [location.pathname]);
+
   return (
     <>
       <Header />

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -1,0 +1,21 @@
+import ModalContainer from 'components/common/modal/ModalContainer';
+import ScrollToTop from 'components/common/scrollToTop';
+import Header from 'components/Header';
+import ScrollToTopButton from 'components/ScrollToTopButton';
+import { Suspense } from 'react';
+import { Outlet } from 'react-router-dom';
+import LoadingPage from './LoadingPage';
+
+export default function Root() {
+  return (
+    <>
+      <ScrollToTop />
+      <ScrollToTopButton />
+      <Header />
+      <ModalContainer />
+      <Suspense fallback={<LoadingPage />}>
+        <Outlet />
+      </Suspense>
+    </>
+  );
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,9 +1,10 @@
 import React, { Suspense } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Header from 'components/Header';
 import ModalContainer from 'components/common/modal/ModalContainer';
 import ScrollToTop from 'components/common/scrollToTop';
 import ScrollToTopButton from 'components/ScrollToTopButton';
+import { useIsLogin } from 'hooks';
 
 const MainComponentPage = React.lazy(() => import('pages/MainPage'));
 const MyPageComonentPage = React.lazy(() => import('pages/MyPage'));
@@ -35,16 +36,37 @@ const Router = () => {
       <Suspense fallback={<LoadingPage />}>
         <Routes>
           <Route path="/" element={<MainComponentPage />} />
-          <Route path="/mypage" element={<MyPageComonentPage />} />
+          <Route
+            path="/mypage"
+            element={
+              useIsLogin() ? (
+                <MyPageComonentPage />
+              ) : (
+                <Navigate to="/" replace />
+              )
+            }
+          />
           <Route path="/findproject" element={<FindProjectComponentPage />} />
           <Route path="/project/:id" element={<ProjectDetailComponentPage />} />
           <Route
             path="/project/write"
-            element={<ProjectWriteComponentPage />}
+            element={
+              useIsLogin() ? (
+                <ProjectWriteComponentPage />
+              ) : (
+                <Navigate to="/" replace />
+              )
+            }
           />
           <Route
             path="/project/write/:id"
-            element={<ProjectEditComponentPage />}
+            element={
+              useIsLogin() ? (
+                <ProjectEditComponentPage />
+              ) : (
+                <Navigate to="/" replace />
+              )
+            }
           />
           <Route path="/profile/:id" element={<PublicProfileComponentPage />} />
           <Route path="*" element={<ErrorPage />} />

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -29,7 +29,8 @@ const ErrorPage = React.lazy(() => import('pages/ErrorPage'));
 
 const router = createBrowserRouter(
   createRoutesFromElements(
-    <Route element={<Root />} errorElement={<ErrorPage />}>
+    <Route element={<Root />}>
+      <Route path="*" element={<ErrorPage />} />
       <Route path="/" element={<MainComponentPage />} />
       <Route
         path="/mypage"

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,10 +1,12 @@
-import React, { Suspense } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import Header from 'components/Header';
-import ModalContainer from 'components/common/modal/ModalContainer';
-import ScrollToTop from 'components/common/scrollToTop';
-import ScrollToTopButton from 'components/ScrollToTopButton';
+import React from 'react';
+import {
+  Route,
+  Navigate,
+  createBrowserRouter,
+  createRoutesFromElements,
+} from 'react-router-dom';
 import { useIsLogin } from 'hooks';
+import Root from 'pages/Root';
 
 const MainComponentPage = React.lazy(() => import('pages/MainPage'));
 const MyPageComonentPage = React.lazy(() => import('pages/MyPage'));
@@ -24,56 +26,42 @@ const PublicProfileComponentPage = React.lazy(
   () => import('pages/PublicProfilePage'),
 );
 const ErrorPage = React.lazy(() => import('pages/ErrorPage'));
-const LoadingPage = React.lazy(() => import('pages/LoadingPage'));
 
-const Router = () => {
-  return (
-    <BrowserRouter>
-      <ScrollToTop />
-      <ScrollToTopButton />
-      <Header />
-      <ModalContainer />
-      <Suspense fallback={<LoadingPage />}>
-        <Routes>
-          <Route path="/" element={<MainComponentPage />} />
-          <Route
-            path="/mypage"
-            element={
-              useIsLogin() ? (
-                <MyPageComonentPage />
-              ) : (
-                <Navigate to="/" replace />
-              )
-            }
-          />
-          <Route path="/findproject" element={<FindProjectComponentPage />} />
-          <Route path="/project/:id" element={<ProjectDetailComponentPage />} />
-          <Route
-            path="/project/write"
-            element={
-              useIsLogin() ? (
-                <ProjectWriteComponentPage />
-              ) : (
-                <Navigate to="/" replace />
-              )
-            }
-          />
-          <Route
-            path="/project/write/:id"
-            element={
-              useIsLogin() ? (
-                <ProjectEditComponentPage />
-              ) : (
-                <Navigate to="/" replace />
-              )
-            }
-          />
-          <Route path="/profile/:id" element={<PublicProfileComponentPage />} />
-          <Route path="*" element={<ErrorPage />} />
-        </Routes>
-      </Suspense>
-    </BrowserRouter>
-  );
-};
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route element={<Root />} errorElement={<ErrorPage />}>
+      <Route path="/" element={<MainComponentPage />} />
+      <Route
+        path="/mypage"
+        element={
+          useIsLogin() ? <MyPageComonentPage /> : <Navigate to="/" replace />
+        }
+      />
+      <Route path="/findproject" element={<FindProjectComponentPage />} />
+      <Route path="/project/:id" element={<ProjectDetailComponentPage />} />
+      <Route
+        path="/project/write"
+        element={
+          useIsLogin() ? (
+            <ProjectWriteComponentPage />
+          ) : (
+            <Navigate to="/" replace />
+          )
+        }
+      />
+      <Route
+        path="/project/write/:id"
+        element={
+          useIsLogin() ? (
+            <ProjectEditComponentPage />
+          ) : (
+            <Navigate to="/" replace />
+          )
+        }
+      />
+      <Route path="/profile/:id" element={<PublicProfileComponentPage />} />
+    </Route>,
+  ),
+);
 
-export default Router;
+export default router;

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -7,7 +7,7 @@ export const preventScroll = (): number => {
   document.body.style.position = 'fixed';
   document.body.style.width = '100%';
   document.body.style.top = `-${currentScrollY}px`; // 현재 스크롤 위치
-  document.body.style.overflowY = 'scroll';
+  document.body.style.overflowY = 'overlay';
   return currentScrollY;
 };
 


### PR DESCRIPTION
## 개요 🔎

Closes #175 
로그인 권한 예외처리 기능을 추가했습니다.

## 작업사항 📝

- 로그인 권한에 따라 페이지 라우팅 (마이페이지, 글쓰기/수정 접근 시 홈으로 리다이렉션)
- 로딩/에러 페이지에서 헤더 보여주기
- 로그인 안 된 상태에서 firebase 유저 컬렉션 조회 제한
- 로그인이 필요한 기능 클릭 시 로그인 모달창 열기 (쪽지 보내기, 프로젝트 지원하기, 새글쓰기)

## 패키지 설치내용 📦

.