### PR TITLE
[fix] 썸네일 이미지 업로드 버튼 색상 처리 & 확장자 고정

### DIFF
--- a/src/components/editpage/ProjectEditPageBody.tsx
+++ b/src/components/editpage/ProjectEditPageBody.tsx
@@ -7,16 +7,17 @@ import styled from '@emotion/styled';
 
 interface Props {
   imageRef: any;
-  editFormValue: any;
+  editFormValue: EditType.EditFormType;
   setEditFormValue: (value: EditType.EditFormType) => void;
+  setEditThumbnail: (value: any) => void;
   onFormValueChangeEvent: (e: ChangeEvent<HTMLInputElement>) => void;
   onAddThumbnailImageEvent: () => void;
 }
-
 const ProjectEditPageBody = ({
   imageRef,
   editFormValue,
   setEditFormValue,
+  setEditThumbnail,
   onFormValueChangeEvent,
   onAddThumbnailImageEvent,
 }: Props) => {
@@ -29,6 +30,11 @@ const ProjectEditPageBody = ({
     endDate,
     deadline,
   } = editFormValue;
+  const handleAddThumbnailImageChange = () => {
+    setEditThumbnail(
+      imageRef.current?.files?.length ? imageRef.current.files[0] : '',
+    );
+  };
 
   return (
     <BodyContainer>
@@ -73,8 +79,16 @@ const ProjectEditPageBody = ({
       </BodyDeadlineBox>
       <BodyThumbnailBox>
         <BodyText>썸네일 추가</BodyText>
-        <BodyThumbnailImage type="file" accept="image/*" ref={imageRef} />
-        <BodyThumbnailButton onClick={onAddThumbnailImageEvent}>
+        <BodyThumbnailImage
+          type="file"
+          accept="image/jpg, image/png, image/jpeg"
+          ref={imageRef}
+          onChange={handleAddThumbnailImageChange}
+        />
+        <BodyThumbnailButton
+          onClick={onAddThumbnailImageEvent}
+          imageRef={imageRef}
+        >
           사진 추가하기
         </BodyThumbnailButton>
       </BodyThumbnailBox>
@@ -152,7 +166,8 @@ const BodyThumbnailButton = styled.button`
   padding: 0.625rem 1.75rem;
   width: 226px;
   height: 43px;
-  background: ${COLORS.violetB500};
+  background: ${(props: { imageRef: any }) =>
+    props.imageRef.current?.files?.length ? COLORS.gray300 : COLORS.violetB400};
   color: ${COLORS.white};
   border-radius: 8px;
   margin-left: 2rem;

--- a/src/components/writepage/ProjectWritePageBody.tsx
+++ b/src/components/writepage/ProjectWritePageBody.tsx
@@ -20,6 +20,15 @@ const ProjectWritePageBody = ({
   onFormValueChagneEvent,
   onAddThumbnailImageEvent,
 }: Props) => {
+  const handleAddThumbnailImageChange = () => {
+    setWriteFormValue({
+      ...writeFormValue,
+      thumbnail: imageRef.current?.files?.length
+        ? imageRef.current.files[0]
+        : '',
+    });
+  };
+
   return (
     <WritePageBodyContainer>
       <WritePageBodyPositionBox>
@@ -63,10 +72,14 @@ const ProjectWritePageBody = ({
         <WritePageBodyText>썸네일 추가</WritePageBodyText>
         <WritePageBodyThumbnailImage
           type="file"
-          accept="image/*"
+          accept="image/jpg, image/png, image/jpeg"
           ref={imageRef}
+          onChange={handleAddThumbnailImageChange}
         />
-        <WritePageBodyThumbnailButton onClick={onAddThumbnailImageEvent}>
+        <WritePageBodyThumbnailButton
+          onClick={onAddThumbnailImageEvent}
+          writeFormValue={writeFormValue}
+        >
           사진 추가하기
         </WritePageBodyThumbnailButton>
       </WritePageBodyThumbnailBox>
@@ -144,7 +157,8 @@ const WritePageBodyThumbnailButton = styled.button`
   padding: 0.625rem 1.75rem;
   width: 226px;
   height: 43px;
-  background: ${COLORS.violetB500};
+  background: ${(props: { writeFormValue: WriteType.WriteFormType }) =>
+    props.writeFormValue.thumbnail ? COLORS.gray300 : COLORS.violetB400};
   color: #ffffff;
   border-radius: 8px;
   margin-left: 2rem;

--- a/src/hooks/useEditBoard.ts
+++ b/src/hooks/useEditBoard.ts
@@ -23,6 +23,7 @@ const useEdtiBoard = () => {
   const imageRef = useRef<any>(null);
 
   const [editFormValue, setEditFormValue] = useState(state);
+  const [editThumbnail, setEditThumbnail] = useState(null);
 
   const { isOpen, handleModalStateChange } = useModal(false);
   const { showToast, ToastMessage, handleToastPopup } = useToastPopup();
@@ -83,12 +84,11 @@ const useEdtiBoard = () => {
     if (!params.id) {
       return;
     }
-    const file = imageRef.current.files[0];
-    if (!file) {
+    if (!editThumbnail) {
       editProjectRequest(imageRef.current.files[0]);
       return;
     }
-    const resizedFile = await resizeFile(file);
+    const resizedFile = await resizeFile(editThumbnail);
     editProjectRequest(resizedFile);
   };
 
@@ -135,6 +135,7 @@ const useEdtiBoard = () => {
     ToastMessage,
     editFormValue,
     setEditFormValue,
+    setEditThumbnail,
     handleModalStateChange,
     handleFormValueChange,
     handleAddThumbnailImage,

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -61,15 +61,14 @@ const useWrite = () => {
   }, [writeFormValue]);
 
   const handleCreateProjectButtonClick = async () => {
+    const { thumbnail } = writeFormValue;
     const markdownText = editRef.current.getInstance().getMarkdown();
 
-    const file = imageRef.current.files[0];
-
-    if (!file) {
+    if (!thumbnail) {
       const docId = await firebaseCreateProjectRequest(
         writeFormValue,
         markdownText,
-        imageRef.current.files[0],
+        null,
         uid,
       );
       navigate(`/project/${docId}`, {
@@ -78,7 +77,7 @@ const useWrite = () => {
       return;
     }
 
-    const resizedImage = await resizeFile(file);
+    const resizedImage = await resizeFile(thumbnail);
 
     const docId = await firebaseCreateProjectRequest(
       writeFormValue,
@@ -150,6 +149,7 @@ const initialWriteFormValue = {
     frontend: 0,
     backend: 0,
   },
+  thumbnail: null,
   plannerStack: [],
   developerStack: [],
   designerStack: [],

--- a/src/pages/ProjectEditPage.tsx
+++ b/src/pages/ProjectEditPage.tsx
@@ -16,6 +16,7 @@ const ProjectEditPage = () => {
     ToastMessage,
     editFormValue,
     setEditFormValue,
+    setEditThumbnail,
     handleModalStateChange,
     handleFormValueChange,
     handleAddThumbnailImage,
@@ -34,6 +35,7 @@ const ProjectEditPage = () => {
           imageRef={imageRef}
           editFormValue={editFormValue}
           setEditFormValue={setEditFormValue}
+          setEditThumbnail={setEditThumbnail}
           onFormValueChangeEvent={handleFormValueChange}
           onAddThumbnailImageEvent={handleAddThumbnailImage}
         />

--- a/src/types/write/writeType.ts
+++ b/src/types/write/writeType.ts
@@ -7,6 +7,7 @@ export namespace WriteType {
     plannerStack: string[];
     developerStack: string[];
     designerStack: string[];
+    thumbnail: any;
     startDate: string;
     endDate: string;
     deadline: string;


### PR DESCRIPTION
## 개요 :mag_right:

Closes #182 
썸네일 이미지 업로드시 버튼 색상 변경처리 및 Input file 타입의 확장자를 고정 했습니다. 

## 작업사항 :pencil:

- 썸네일 이미지 업로드 onChagne와 State처리를 통해 렌더링시켜 버튼 색상처리
- Input type file의 Option accept를 이용해 jpg, png, jpeg 확장자만 올라오도록 수정

## 패키지 설치내용 :package: