### PR TITLE
[fix] 무한 스크롤 기본 불러오기 값 15개로 수정

### DIFF
--- a/src/apis/boardService.ts
+++ b/src/apis/boardService.ts
@@ -82,7 +82,7 @@ export const firebaseInfinityScrollProjectDataRequest = async (
     q = query(
       collection(firestore, 'post'),
       orderBy('createdAt', 'desc'),
-      limit(9),
+      limit(15),
     );
   }
 

--- a/src/components/editpage/ProjectEditPageBody.tsx
+++ b/src/components/editpage/ProjectEditPageBody.tsx
@@ -9,17 +9,17 @@ interface Props {
   imageRef: any;
   editFormValue: EditType.EditFormType;
   setEditFormValue: (value: EditType.EditFormType) => void;
-  setEditThumbnail: (value: any) => void;
   onFormValueChangeEvent: (e: ChangeEvent<HTMLInputElement>) => void;
   onAddThumbnailImageEvent: () => void;
+  onAddThumbnailImageChangeEvent: () => void;
 }
 const ProjectEditPageBody = ({
   imageRef,
   editFormValue,
   setEditFormValue,
-  setEditThumbnail,
   onFormValueChangeEvent,
   onAddThumbnailImageEvent,
+  onAddThumbnailImageChangeEvent,
 }: Props) => {
   const {
     positions,
@@ -30,11 +30,6 @@ const ProjectEditPageBody = ({
     endDate,
     deadline,
   } = editFormValue;
-  const handleAddThumbnailImageChange = () => {
-    setEditThumbnail(
-      imageRef.current?.files?.length ? imageRef.current.files[0] : '',
-    );
-  };
 
   return (
     <BodyContainer>
@@ -86,7 +81,7 @@ const ProjectEditPageBody = ({
           type="file"
           accept="image/jpg, image/png, image/jpeg"
           ref={imageRef}
-          onChange={handleAddThumbnailImageChange}
+          onChange={onAddThumbnailImageChangeEvent}
         />
         <BodyThumbnailButton
           onClick={onAddThumbnailImageEvent}

--- a/src/components/writepage/ProjectWritePageBody.tsx
+++ b/src/components/writepage/ProjectWritePageBody.tsx
@@ -11,6 +11,7 @@ interface Props {
   setWriteFormValue: (value: WriteType.WriteFormType) => void;
   onFormValueChangeEvent: (e: React.ChangeEvent<HTMLInputElement>) => void; // eslint-disable-line no-unused-vars
   onAddThumbnailImageEvent: () => void;
+  onAddThumbnailImageChangeEvent: () => void;
 }
 
 const ProjectWritePageBody = ({
@@ -19,16 +20,8 @@ const ProjectWritePageBody = ({
   setWriteFormValue,
   onFormValueChangeEvent,
   onAddThumbnailImageEvent,
+  onAddThumbnailImageChangeEvent,
 }: Props) => {
-  const handleAddThumbnailImageChange = () => {
-    setWriteFormValue({
-      ...writeFormValue,
-      thumbnail: imageRef.current?.files?.length
-        ? imageRef.current.files[0]
-        : '',
-    });
-  };
-
   return (
     <WritePageBodyContainer>
       <WritePageBodyPositionBox>
@@ -77,7 +70,7 @@ const ProjectWritePageBody = ({
           type="file"
           accept="image/jpg, image/png, image/jpeg"
           ref={imageRef}
-          onChange={handleAddThumbnailImageChange}
+          onChange={onAddThumbnailImageChangeEvent}
         />
         <WritePageBodyThumbnailButton
           onClick={onAddThumbnailImageEvent}

--- a/src/hooks/useEditBoard.ts
+++ b/src/hooks/useEditBoard.ts
@@ -96,6 +96,12 @@ const useEditBoard = () => {
     imageRef.current.click();
   }, [imageRef]);
 
+  const handleAddThumbnailImageChange = () => {
+    setEditThumbnail(
+      imageRef.current?.files?.length ? imageRef.current.files[0] : '',
+    );
+  };
+
   const handleFormValueChange = useCallback(
     (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const { name, value } = e.target;
@@ -135,11 +141,11 @@ const useEditBoard = () => {
     ToastMessage,
     editFormValue,
     setEditFormValue,
-    setEditThumbnail,
-    handleModalStateChange,
     handleFormValueChange,
+    handleModalStateChange,
     handleAddThumbnailImage,
     handleEditProjectButtonClick,
+    handleAddThumbnailImageChange,
     handleCheckValidationButtonClick,
   };
 };

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -94,6 +94,17 @@ const useWrite = () => {
     imageRef.current.click();
   }, [imageRef]);
 
+  const handleAddThumbnailImageChange = () => {
+    setWriteFormValue({
+      ...writeFormValue,
+      thumbnail: imageRef.current?.files?.length
+        ? imageRef.current.files[0]
+        : '',
+    });
+  };
+
+  console.log(writeFormValue);
+
   const handleFormValueChange = useCallback(
     (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const { name, value } = e.target;
@@ -133,9 +144,10 @@ const useWrite = () => {
     ToastMessage,
     writeFormValue,
     setWriteFormValue,
-    handleModalStateChange,
     handleFormValueChange,
+    handleModalStateChange,
     handleAddThumbnailImage,
+    handleAddThumbnailImageChange,
     handleCreateProjectButtonClick,
     handleCheckValidationButtonClick,
   };

--- a/src/pages/ProjectEditPage.tsx
+++ b/src/pages/ProjectEditPage.tsx
@@ -16,11 +16,11 @@ const ProjectEditPage = () => {
     ToastMessage,
     editFormValue,
     setEditFormValue,
-    setEditThumbnail,
-    handleModalStateChange,
     handleFormValueChange,
+    handleModalStateChange,
     handleAddThumbnailImage,
     handleEditProjectButtonClick,
+    handleAddThumbnailImageChange,
     handleCheckValidationButtonClick,
   } = useEdtiBoard();
 
@@ -35,9 +35,9 @@ const ProjectEditPage = () => {
           imageRef={imageRef}
           editFormValue={editFormValue}
           setEditFormValue={setEditFormValue}
-          setEditThumbnail={setEditThumbnail}
           onFormValueChangeEvent={handleFormValueChange}
           onAddThumbnailImageEvent={handleAddThumbnailImage}
+          onAddThumbnailImageChangeEvent={handleAddThumbnailImageChange}
         />
         <ProjectEditPageFooter
           editRef={editRef}

--- a/src/pages/ProjectWritePage.tsx
+++ b/src/pages/ProjectWritePage.tsx
@@ -19,6 +19,7 @@ const ProjectWritePage = () => {
     handleFormValueChange,
     handleModalStateChange,
     handleAddThumbnailImage,
+    handleAddThumbnailImageChange,
     handleCreateProjectButtonClick,
     handleCheckValidationButtonClick,
   } = useWrite();
@@ -36,6 +37,7 @@ const ProjectWritePage = () => {
           setWriteFormValue={setWriteFormValue}
           onFormValueChangeEvent={handleFormValueChange}
           onAddThumbnailImageEvent={handleAddThumbnailImage}
+          onAddThumbnailImageChangeEvent={handleAddThumbnailImageChange}
         />
         <ProjectWritePageFooter
           editRef={editRef}


### PR DESCRIPTION
## 개요 :mag_right:

무한 스크롤 기본 불러오기 값 15개로 수정

## 작업사항 :pencil:

- firebase 무한 스크롤 default Limit(15)로 수정 
- body안 function hooks로 분리

## 패키지 설치내용 :package: