### PR TITLE
[feat] 헤더 모바일 UI 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -53,6 +53,7 @@ const Header = () => {
     ],
   });
 
+  // 모바일일 경우 모바일 헤더 노출
   if (isMobile) {
     return <MobileHeader />;
   }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,7 +36,7 @@ const Header = () => {
   }, [location.pathname]);
 
   const { uid } = useAuth();
-  const [{ data: notes }, { data: notifiactions }] = useQueries({
+  const [{ data: notes }, { data: notifications }] = useQueries({
     queries: [
       {
         queryKey: ['inbox', uid],
@@ -55,7 +55,7 @@ const Header = () => {
 
   // 모바일일 경우 모바일 헤더 노출
   if (isMobile) {
-    return <MobileHeader />;
+    return <MobileHeader notes={notes} notifications={notifications} />;
   }
 
   return (
@@ -96,8 +96,8 @@ const Header = () => {
                   알림
                   <Count>
                     (
-                    {notifiactions
-                      ? notifiactions.filter(
+                    {notifications
+                      ? notifications.filter(
                           ({ isRead }: Partial<Notification>) => !isRead,
                         ).length
                       : 0}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,13 @@ import { Link, NavLink, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
 import WebContainer from './common/WebContainer';
 import PopupContainer from './popup/PopupContainer';
-import { useAuth, useGlobalModal, useHeader, usePopup } from 'hooks';
+import {
+  useAuth,
+  useGlobalModal,
+  useHeader,
+  useIsMobile,
+  usePopup,
+} from 'hooks';
 import COLORS from 'assets/styles/colors';
 import { useEffect } from 'react';
 import { useQueries } from '@tanstack/react-query';
@@ -10,12 +16,15 @@ import { getInboxNotes } from 'apis/notes';
 import { getNotifications } from 'apis/notifications';
 import { staleTime } from 'utils/staleTime';
 
+import MobileHeader from './MobileHeader';
+
 interface headerTypes {
   isMain: boolean;
   hideGradient: boolean;
 }
 
 const Header = () => {
+  const isMobile = useIsMobile();
   const { closePopup, toggleNoteBox, toggleNotificationBox } = usePopup();
   const { openModal } = useGlobalModal();
   const { isMain, isLoggedIn, hideGradient, handleLogoutClick } = useHeader();
@@ -44,6 +53,10 @@ const Header = () => {
     ],
   });
 
+  if (isMobile) {
+    return <MobileHeader />;
+  }
+
   return (
     <HeaderContainer isMain={isMain} hideGradient={hideGradient}>
       <WebContainer>
@@ -61,15 +74,6 @@ const Header = () => {
                   '새 글 쓰기'
                 )}
               </NavItemLi>
-              {/* {isLoggedIn ? (
-                <NavItemLi>
-                  <NavItemLink to={'/project/write'}>새 글 쓰기</NavItemLink>
-                </NavItemLi>
-              ) : (
-                <NavItemLi onClick={() => openModal('login', 0)}>
-                  새 글 쓰기
-                </NavItemLi>
-              )} */}
               <NavItemLi>
                 <NavItemLink to={'/findproject'}>팀원찾기</NavItemLink>
               </NavItemLi>
@@ -147,12 +151,12 @@ const HeaderWrapper = styled.div`
   align-items: center;
 `;
 
-const LogoBoxH1 = styled.h1`
-  font-size: 2.5rem;
+export const LogoBoxH1 = styled.h1<{ isMobile?: boolean }>`
+  font-size: ${({ isMobile }) => (isMobile ? '1.625rem' : '2.5rem')};
   font-weight: 800;
   color: ${COLORS.violetB500};
-  margin-top: -0.5rem;
-  margin-left: 1.438rem;
+  margin-top: ${({ isMobile }) => (isMobile ? '-0.2rem' : '-0.5rem')};
+  margin-left: ${({ isMobile }) => (isMobile ? '0' : '1.438rem')};
   cursor: pointer;
 `;
 

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -1,0 +1,140 @@
+import { Link } from 'react-router-dom';
+import styled from '@emotion/styled';
+import { GrMail } from 'react-icons/gr';
+import { FiChevronLeft } from 'react-icons/fi';
+import { IoNotifications, IoMenu } from 'react-icons/io5';
+import { useHeader } from 'hooks';
+import { LogoBoxH1 } from './Header';
+import COLORS from 'assets/styles/colors';
+
+const MobileHeader = () => {
+  const { isMain, isLoggedIn, handleLogoutClick } = useHeader();
+
+  return (
+    <MobileHeaderContainer>
+      <MobileHeaderWrapper>
+        {!isMain && (
+          <MobileMenuItem>
+            <MobileChevronLeftIcon />
+          </MobileMenuItem>
+        )}
+        <LogoBoxH1 isMobile={true}>
+          <Link to={'/'}> Detto</Link>
+        </LogoBoxH1>
+        <MobileMenuList>
+          {isMain && isLoggedIn ? (
+            <>
+              <MobileMenuItem>
+                <MobileNoteIcon />
+              </MobileMenuItem>
+              <MobileMenuItem>
+                <MobileNotificationIcon />
+              </MobileMenuItem>
+            </>
+          ) : (
+            ''
+          )}
+          <MobileMenuItem>
+            <MobileMenuIcon />
+          </MobileMenuItem>
+        </MobileMenuList>
+      </MobileHeaderWrapper>
+
+      {/* 드롭다운 메뉴 */}
+      <DropdownBox>
+        <DropdownList>
+          <DropdownItem>로그인</DropdownItem>
+          <DropdownItem>로그아웃</DropdownItem>
+          <DropdownItem>팀원찾기</DropdownItem>
+          <DropdownItem>새 글쓰기</DropdownItem>
+          <DropdownItem>마이페이지</DropdownItem>
+        </DropdownList>
+      </DropdownBox>
+    </MobileHeaderContainer>
+  );
+};
+
+export default MobileHeader;
+
+const MobileHeaderContainer = styled.header`
+  padding: 0 1.5rem;
+`;
+
+const MobileHeaderWrapper = styled.div`
+  width: 100%;
+  height: 3rem;
+  background-color: ${COLORS.white};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const MobileMenuList = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+
+  & > div {
+    &:not(:last-child) {
+      margin-right: 1.25rem;
+    }
+  }
+`;
+
+const MobileMenuItem = styled.div`
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const MobileNoteIcon = styled(GrMail)`
+  font-size: 1.25rem;
+  color: ${COLORS.gray750};
+`;
+
+const MobileNotificationIcon = styled(IoNotifications)`
+  font-size: 1.25rem;
+  color: ${COLORS.gray750};
+`;
+
+const MobileMenuIcon = styled(IoMenu)`
+  font-size: 1.75rem;
+  color: ${COLORS.gray750};
+  position: relative;
+`;
+
+const MobileChevronLeftIcon = styled(FiChevronLeft)`
+  font-size: 1.875rem;
+  color: ${COLORS.gray750};
+  margin-top: 0.25rem;
+`;
+
+const DropdownBox = styled.div`
+  position: absolute;
+  right: 1.5rem;
+  width: 7.75rem;
+  min-height: 10.75rem;
+  background-color: ${COLORS.white};
+  padding: 20px 0;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  z-index: 99;
+`;
+
+const DropdownList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+`;
+
+const DropdownItem = styled.li`
+  height: 2.5rem;
+  padding: 10px;
+  line-height: 1.25rem;
+  font-size: 0.875rem;
+  text-align: center;
+  font-weight: 500;
+  color: ${COLORS.gray850};
+`;

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { GrMail } from 'react-icons/gr';
@@ -5,10 +6,16 @@ import { FiChevronLeft } from 'react-icons/fi';
 import { IoNotifications, IoMenu } from 'react-icons/io5';
 import { useGlobalModal, useHeader, usePopup } from 'hooks';
 import { LogoBoxH1 } from './Header';
+import PopupContainer from './popup/PopupContainer';
 import COLORS from 'assets/styles/colors';
-import { useEffect } from 'react';
 
-const MobileHeader = () => {
+interface MobileHeaderProps {
+  notes: any;
+  notifications: any;
+}
+
+const MobileHeader = ({ notes, notifications }: MobileHeaderProps) => {
+  const { closePopup, toggleNoteBox, toggleNotificationBox } = usePopup();
   const {
     isMain,
     isLoggedIn,
@@ -19,7 +26,6 @@ const MobileHeader = () => {
     closeDropdownMenu,
   } = useHeader();
   const { openModal } = useGlobalModal();
-  const { closePopup } = usePopup();
 
   // 페이지 이동 시 팝업 / 드롭다운 메뉴 닫기
   useEffect(() => {
@@ -30,6 +36,7 @@ const MobileHeader = () => {
   return (
     <MobileHeaderContainer>
       <MobileHeaderWrapper>
+        {isLoggedIn && <PopupContainer />}
         {!isMain && (
           <MobileMenuItem onClick={handleGoBackClick}>
             <MobileChevronLeftIcon />
@@ -41,18 +48,29 @@ const MobileHeader = () => {
         <MobileMenuList>
           {isMain && isLoggedIn ? (
             <>
-              <MobileMenuItem>
-                {/* 쪽지 */}
+              <MobileMenuItem onClick={toggleNoteBox}>
                 <CountBox>
                   <MobileNoteIcon />
-                  <MobileCount>12</MobileCount>
+                  {/* TODO:: 쪽지 0개일 경우 카운트 안 보이도록 처리 필요 */}
+                  <MobileCount>
+                    {
+                      notes?.filter(({ isRead }: Partial<Note>) => !isRead)
+                        .length
+                    }
+                  </MobileCount>
                 </CountBox>
               </MobileMenuItem>
-              <MobileMenuItem>
-                {/* 알림 */}
+              <MobileMenuItem onClick={toggleNotificationBox}>
                 <CountBox>
                   <MobileNotificationIcon />
-                  <MobileCount>1</MobileCount>
+                  {/* TODO:: 알림 0개일 경우 카운트 안 보이도록 처리 필요 */}
+                  <MobileCount>
+                    {
+                      notifications?.filter(
+                        ({ isRead }: Partial<Notification>) => !isRead,
+                      ).length
+                    }
+                  </MobileCount>
                 </CountBox>
               </MobileMenuItem>
             </>
@@ -61,12 +79,10 @@ const MobileHeader = () => {
           )}
           <MobileMenuItem onClick={handleDropdownClick}>
             <MobileMenuIcon />
-            {/* 메뉴 */}
           </MobileMenuItem>
         </MobileMenuList>
       </MobileHeaderWrapper>
 
-      {/* 드롭다운 메뉴 */}
       {showDropwdown && (
         <DropdownBox>
           <DropdownList>
@@ -75,15 +91,12 @@ const MobileHeader = () => {
                 로그인
               </DropdownItem>
             )}
-
             {isLoggedIn && (
               <DropdownItem onClick={handleLogoutClick}>로그아웃</DropdownItem>
             )}
-
             <DropdownItem>
               <Link to={'/findproject'}>팀원찾기</Link>
             </DropdownItem>
-
             <DropdownItem onClick={() => !isLoggedIn && openModal('login', 0)}>
               {isLoggedIn ? (
                 <Link to={'/project/write'}>새 글 쓰기</Link>
@@ -91,7 +104,6 @@ const MobileHeader = () => {
                 '새 글 쓰기'
               )}
             </DropdownItem>
-
             {isLoggedIn && (
               <DropdownItem>
                 <Link to={'/mypage'}>마이페이지</Link>

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -3,12 +3,13 @@ import styled from '@emotion/styled';
 import { GrMail } from 'react-icons/gr';
 import { FiChevronLeft } from 'react-icons/fi';
 import { IoNotifications, IoMenu } from 'react-icons/io5';
-import { useHeader } from 'hooks';
+import { useGlobalModal, useHeader } from 'hooks';
 import { LogoBoxH1 } from './Header';
 import COLORS from 'assets/styles/colors';
 
 const MobileHeader = () => {
   const { isMain, isLoggedIn, handleLogoutClick } = useHeader();
+  const { openModal } = useGlobalModal();
 
   return (
     <MobileHeaderContainer>
@@ -41,13 +42,33 @@ const MobileHeader = () => {
       </MobileHeaderWrapper>
 
       {/* 드롭다운 메뉴 */}
+
       <DropdownBox>
         <DropdownList>
-          <DropdownItem>로그인</DropdownItem>
-          <DropdownItem>로그아웃</DropdownItem>
-          <DropdownItem>팀원찾기</DropdownItem>
-          <DropdownItem>새 글쓰기</DropdownItem>
-          <DropdownItem>마이페이지</DropdownItem>
+          {!isLoggedIn && (
+            <DropdownItem onClick={() => openModal('login', 0)}>
+              {' '}
+              로그인
+            </DropdownItem>
+          )}
+          {isLoggedIn && (
+            <DropdownItem onClick={handleLogoutClick}>로그아웃</DropdownItem>
+          )}
+          <DropdownItem>
+            <Link to={'/findproject'}>팀원찾기</Link>
+          </DropdownItem>
+          <DropdownItem onClick={() => !isLoggedIn && openModal('login', 0)}>
+            {isLoggedIn ? (
+              <Link to={'/project/write'}>새 글 쓰기</Link>
+            ) : (
+              '새 글 쓰기'
+            )}
+          </DropdownItem>
+          {isLoggedIn && (
+            <DropdownItem>
+              <Link to={'/mypage'}>마이페이지</Link>{' '}
+            </DropdownItem>
+          )}
         </DropdownList>
       </DropdownBox>
     </MobileHeaderContainer>

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -8,7 +8,13 @@ import { LogoBoxH1 } from './Header';
 import COLORS from 'assets/styles/colors';
 
 const MobileHeader = () => {
-  const { isMain, isLoggedIn, handleLogoutClick } = useHeader();
+  const {
+    isMain,
+    isLoggedIn,
+    showDropwdown,
+    handleDropdownClick,
+    handleLogoutClick,
+  } = useHeader();
   const { openModal } = useGlobalModal();
 
   return (
@@ -35,42 +41,43 @@ const MobileHeader = () => {
           ) : (
             ''
           )}
-          <MobileMenuItem>
+          <MobileMenuItem onClick={handleDropdownClick}>
             <MobileMenuIcon />
           </MobileMenuItem>
         </MobileMenuList>
       </MobileHeaderWrapper>
 
       {/* 드롭다운 메뉴 */}
-
-      <DropdownBox>
-        <DropdownList>
-          {!isLoggedIn && (
-            <DropdownItem onClick={() => openModal('login', 0)}>
-              {' '}
-              로그인
-            </DropdownItem>
-          )}
-          {isLoggedIn && (
-            <DropdownItem onClick={handleLogoutClick}>로그아웃</DropdownItem>
-          )}
-          <DropdownItem>
-            <Link to={'/findproject'}>팀원찾기</Link>
-          </DropdownItem>
-          <DropdownItem onClick={() => !isLoggedIn && openModal('login', 0)}>
-            {isLoggedIn ? (
-              <Link to={'/project/write'}>새 글 쓰기</Link>
-            ) : (
-              '새 글 쓰기'
+      {showDropwdown && (
+        <DropdownBox>
+          <DropdownList>
+            {!isLoggedIn && (
+              <DropdownItem onClick={() => openModal('login', 0)}>
+                {' '}
+                로그인
+              </DropdownItem>
             )}
-          </DropdownItem>
-          {isLoggedIn && (
+            {isLoggedIn && (
+              <DropdownItem onClick={handleLogoutClick}>로그아웃</DropdownItem>
+            )}
             <DropdownItem>
-              <Link to={'/mypage'}>마이페이지</Link>{' '}
+              <Link to={'/findproject'}>팀원찾기</Link>
             </DropdownItem>
-          )}
-        </DropdownList>
-      </DropdownBox>
+            <DropdownItem onClick={() => !isLoggedIn && openModal('login', 0)}>
+              {isLoggedIn ? (
+                <Link to={'/project/write'}>새 글 쓰기</Link>
+              ) : (
+                '새 글 쓰기'
+              )}
+            </DropdownItem>
+            {isLoggedIn && (
+              <DropdownItem>
+                <Link to={'/mypage'}>마이페이지</Link>{' '}
+              </DropdownItem>
+            )}
+          </DropdownList>
+        </DropdownBox>
+      )}
     </MobileHeaderContainer>
   );
 };

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -19,7 +19,7 @@ const MobileHeader = () => {
     closeDropdownMenu,
   } = useHeader();
   const { openModal } = useGlobalModal();
-  const { closePopup, toggleNoteBox, toggleNotificationBox } = usePopup();
+  const { closePopup } = usePopup();
 
   // 페이지 이동 시 팝업 / 드롭다운 메뉴 닫기
   useEffect(() => {
@@ -42,10 +42,18 @@ const MobileHeader = () => {
           {isMain && isLoggedIn ? (
             <>
               <MobileMenuItem>
-                <MobileNoteIcon />
+                {/* 쪽지 */}
+                <CountBox>
+                  <MobileNoteIcon />
+                  <MobileCount>12</MobileCount>
+                </CountBox>
               </MobileMenuItem>
               <MobileMenuItem>
-                <MobileNotificationIcon />
+                {/* 알림 */}
+                <CountBox>
+                  <MobileNotificationIcon />
+                  <MobileCount>1</MobileCount>
+                </CountBox>
               </MobileMenuItem>
             </>
           ) : (
@@ -53,6 +61,7 @@ const MobileHeader = () => {
           )}
           <MobileMenuItem onClick={handleDropdownClick}>
             <MobileMenuIcon />
+            {/* 메뉴 */}
           </MobileMenuItem>
         </MobileMenuList>
       </MobileHeaderWrapper>
@@ -63,16 +72,18 @@ const MobileHeader = () => {
           <DropdownList>
             {!isLoggedIn && (
               <DropdownItem onClick={() => openModal('login', 0)}>
-                {' '}
                 로그인
               </DropdownItem>
             )}
+
             {isLoggedIn && (
               <DropdownItem onClick={handleLogoutClick}>로그아웃</DropdownItem>
             )}
+
             <DropdownItem>
               <Link to={'/findproject'}>팀원찾기</Link>
             </DropdownItem>
+
             <DropdownItem onClick={() => !isLoggedIn && openModal('login', 0)}>
               {isLoggedIn ? (
                 <Link to={'/project/write'}>새 글 쓰기</Link>
@@ -80,9 +91,10 @@ const MobileHeader = () => {
                 '새 글 쓰기'
               )}
             </DropdownItem>
+
             {isLoggedIn && (
               <DropdownItem>
-                <Link to={'/mypage'}>마이페이지</Link>{' '}
+                <Link to={'/mypage'}>마이페이지</Link>
               </DropdownItem>
             )}
           </DropdownList>
@@ -175,4 +187,31 @@ const DropdownItem = styled.li`
   text-align: center;
   font-weight: 500;
   color: ${COLORS.gray850};
+
+  &:hover {
+    color: ${COLORS.violetB500};
+  }
+`;
+
+const CountBox = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+const MobileCount = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: -0.5rem;
+  right: -0.75rem;
+  width: 1.375rem;
+  height: 1.125rem;
+  background-color: ${COLORS.violetB500};
+  border-radius: 4px;
+
+  font-size: 0.75rem;
+  color: ${COLORS.white};
+  font-weight: 900;
 `;

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 import { GrMail } from 'react-icons/gr';
 import { FiChevronLeft } from 'react-icons/fi';
 import { IoNotifications, IoMenu } from 'react-icons/io5';
-import { useGlobalModal, useHeader } from 'hooks';
+import { useGlobalModal, useHeader, usePopup } from 'hooks';
 import { LogoBoxH1 } from './Header';
 import COLORS from 'assets/styles/colors';
+import { useEffect } from 'react';
 
 const MobileHeader = () => {
   const {
@@ -14,14 +15,23 @@ const MobileHeader = () => {
     showDropwdown,
     handleDropdownClick,
     handleLogoutClick,
+    handleGoBackClick,
+    closeDropdownMenu,
   } = useHeader();
   const { openModal } = useGlobalModal();
+  const { closePopup, toggleNoteBox, toggleNotificationBox } = usePopup();
+
+  // 페이지 이동 시 팝업 / 드롭다운 메뉴 닫기
+  useEffect(() => {
+    closePopup();
+    closeDropdownMenu();
+  }, [location.pathname]);
 
   return (
     <MobileHeaderContainer>
       <MobileHeaderWrapper>
         {!isMain && (
-          <MobileMenuItem>
+          <MobileMenuItem onClick={handleGoBackClick}>
             <MobileChevronLeftIcon />
           </MobileMenuItem>
         )}

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -10,6 +10,7 @@ const MAIN_SCROLL_Y = 480;
 const useHeader = () => {
   const [hideGradient, setHideGradient] = useState<boolean>(true);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [showDropwdown, setShowDropdown] = useState<boolean>(false);
   const localUser = useAuth();
 
   const navigate = useNavigate();
@@ -30,6 +31,11 @@ const useHeader = () => {
       navigate('/', { replace: true });
       setIsLoggedIn(false);
     });
+  };
+
+  // 모바일에서 드롭다운 메뉴 표시 여부
+  const handleDropdownClick = () => {
+    setShowDropdown((prev) => !prev);
   };
 
   // 메인 페이지일 경우 스크롤에 따른 배경 그라이언트 함수 이벤트 적용
@@ -59,8 +65,10 @@ const useHeader = () => {
   return {
     isMain,
     isLoggedIn,
+    showDropwdown,
     hideGradient,
     handleLogoutClick,
+    handleDropdownClick,
   };
 };
 

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -38,6 +38,16 @@ const useHeader = () => {
     setShowDropdown((prev) => !prev);
   };
 
+  // 모바일에서 이전 페이지 돌아가기
+  const handleGoBackClick = () => {
+    navigate(-1);
+  };
+
+  // 드롭다운 메뉴 닫기
+  const closeDropdownMenu = () => {
+    setShowDropdown(false);
+  };
+
   // 메인 페이지일 경우 스크롤에 따른 배경 그라이언트 함수 이벤트 적용
   useEffect(() => {
     if (isMain) {
@@ -69,6 +79,8 @@ const useHeader = () => {
     hideGradient,
     handleLogoutClick,
     handleDropdownClick,
+    handleGoBackClick,
+    closeDropdownMenu,
   };
 };
 


### PR DESCRIPTION
## 개요 🔎

Closes #197 

헤더 모바일 UI를 추가했습니다.
기존 헤더의 onClick 이벤트, 링크 등 거의 적용해놓았고, 
로그인, 쪽지 등의 모달창, 팝업들은 모바일에 맞게 달라지는 부분들을 추가적으로 수정해주시면 될 것 같습니다.
(쪽지, 알람 카운트는 일단 UI 잡아두고 기존 로직을 적용 해놓았는데 추가 수정이 필요할 것 같습니다. 👀)

## 작업사항 📝

* 모바일 헤더 UI 컴포넌트 추가
* 뒤로가기 기능 추가
* 기존 onClick 이벤트 등 적용

## 패키지 설치내용 📦
.