### PR TITLE
[fix] 모바일 마이페이지, 헤더 버그 수정

### DIFF
--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -66,10 +66,10 @@ const MobileContentCard = ({
           <ContentCardImg src={defaultThumbnail} />
         )}
         <ContentCardBookmark>
-          {likedProjects.includes(id) && (
+          {likedProjects.includes(id ?? pid) && (
             <AiFillHeart size="1.5rem" color={`${COLORS.pink}`} />
           )}
-          {!likedProjects.includes(id) && (
+          {!likedProjects.includes(id ?? pid) && (
             <AiOutlineHeart size="1.5rem" color={`${COLORS.gray750}`} />
           )}
         </ContentCardBookmark>

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { GrMail } from 'react-icons/gr';
@@ -8,12 +8,14 @@ import { useGlobalModal, useHeader, usePopup } from 'hooks';
 import { LogoBoxH1 } from './Header';
 import PopupContainer from './popup/PopupContainer';
 import COLORS from 'assets/styles/colors';
+import MobileDropdownMenu from './popup/mobile/MobileDropdownMenu';
 
 const MobileHeader = () => {
   const {
     closePopup,
     toggleNoteBox,
     toggleNotificationBox,
+    toggleDropdownMenu,
     unreadNoteCount,
     unreadNotificationCount,
   } = usePopup();
@@ -27,6 +29,14 @@ const MobileHeader = () => {
     closeDropdownMenu,
   } = useHeader();
   const { openModal } = useGlobalModal();
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleDropdownClose = (e: React.MouseEvent<HTMLInputElement>) => {
+    if (dropdownRef.current === e.target) {
+      handleDropdownClick();
+    }
+  };
 
   // 페이지 이동 시 팝업 / 드롭다운 메뉴 닫기
   useEffect(() => {
@@ -75,13 +85,14 @@ const MobileHeader = () => {
           ) : (
             ''
           )}
-          <MobileMenuItem onClick={handleDropdownClick}>
+          <MobileMenuItem onClick={toggleDropdownMenu}>
             <MobileMenuIcon />
           </MobileMenuItem>
         </MobileMenuList>
       </MobileHeaderWrapper>
+      <MobileDropdownMenu />
 
-      {showDropwdown && (
+      {/* {showDropwdown && (
         <DropdownBox>
           <DropdownList>
             {!isLoggedIn && (
@@ -109,7 +120,7 @@ const MobileHeader = () => {
             )}
           </DropdownList>
         </DropdownBox>
-      )}
+      )} */}
     </MobileHeaderContainer>
   );
 };

--- a/src/components/mypage/mobile/MobileUserInfo.tsx
+++ b/src/components/mypage/mobile/MobileUserInfo.tsx
@@ -123,6 +123,7 @@ const MobileUserInfo = ({ user }: MypageInfoProps) => {
         />
       </MobileInfoBox>
       <MobileInfoBox>
+        {/* TODO:: pc 버전 마이페이지처럼 유효성 검사 적용 예정, Alert창 변경 예정 */}
         <MobileInfoEditBtn
           isActive={activeInfoBtn}
           onClick={handleUserInfoConfirm}

--- a/src/components/mypage/mobile/MobileUserInfo.tsx
+++ b/src/components/mypage/mobile/MobileUserInfo.tsx
@@ -145,15 +145,15 @@ const MobileUserInfo = ({ user }: MypageInfoProps) => {
 export default MobileUserInfo;
 
 const MobileUserInfoContainer = styled.div`
-  width: 22.5rem;
+  width: 100%;
   min-height: 29.6875rem;
-  margin: 1.625rem 0.9375rem;
+  margin: 1.625rem 0;
   background: ${COLORS.white};
   padding-bottom: 5rem;
 `;
 
 const MobileInfoBox = styled.div`
-  width: 18.5rem;
+  width: 18.625rem;
   margin: 0 auto;
   &:nth-of-type(2),
   &:nth-of-type(3) {

--- a/src/components/popup/mobile/MobileDropdownMenu.tsx
+++ b/src/components/popup/mobile/MobileDropdownMenu.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom';
+import { useGlobalModal, useHeader, usePopup } from 'hooks';
+import styled from '@emotion/styled';
+import COLORS from 'assets/styles/colors';
+
+const MobileDropdownMenu = () => {
+  const { openModal } = useGlobalModal();
+  const { isLoggedIn, handleLogoutClick } = useHeader();
+  const {
+    popup: { isDropdownOpen },
+    closePopup,
+  } = usePopup();
+
+  if (!isDropdownOpen) return null;
+
+  return (
+    <Backdrop onClick={closePopup}>
+      <DropdownBox>
+        <DropdownList>
+          {!isLoggedIn && (
+            <DropdownItem onClick={() => openModal('login', 0)}>
+              로그인
+            </DropdownItem>
+          )}
+          {isLoggedIn && (
+            <DropdownItem onClick={handleLogoutClick}>로그아웃</DropdownItem>
+          )}
+          <DropdownItem>
+            <Link to={'/findproject'}>팀원찾기</Link>
+          </DropdownItem>
+          <DropdownItem onClick={() => !isLoggedIn && openModal('login', 0)}>
+            {isLoggedIn ? (
+              <Link to={'/project/write'}>새 글 쓰기</Link>
+            ) : (
+              '새 글 쓰기'
+            )}
+          </DropdownItem>
+          {isLoggedIn && (
+            <DropdownItem>
+              <Link to={'/mypage'}>마이페이지</Link>
+            </DropdownItem>
+          )}
+        </DropdownList>
+      </DropdownBox>
+    </Backdrop>
+  );
+};
+
+export default MobileDropdownMenu;
+
+const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+`;
+
+const DropdownBox = styled.div`
+  position: absolute;
+  top: 2.8rem;
+  right: 1.5rem;
+  width: 7.75rem;
+  min-height: 10.75rem;
+  background-color: ${COLORS.white};
+  padding: 20px 0;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  z-index: 99;
+`;
+
+const DropdownList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+`;
+
+const DropdownItem = styled.li`
+  height: 2.5rem;
+  padding: 10px;
+  line-height: 1.25rem;
+  font-size: 0.875rem;
+  text-align: center;
+  font-weight: 500;
+  color: ${COLORS.gray850};
+
+  &:hover {
+    color: ${COLORS.violetB500};
+  }
+`;

--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -14,6 +14,7 @@ const usePopup = () => {
     setPopup({
       isNoteOpen: !popup.isNoteOpen,
       isNotificationOpen: false,
+      isDropdownOpen: false,
     });
   };
 
@@ -22,6 +23,16 @@ const usePopup = () => {
     setPopup({
       isNoteOpen: false,
       isNotificationOpen: !popup.isNotificationOpen,
+      isDropdownOpen: false,
+    });
+  };
+
+  // 모바일 드랍다운 토글 (쪽지함이 열려있으면 닫기)
+  const toggleDropdownMenu = () => {
+    setPopup({
+      isNoteOpen: false,
+      isNotificationOpen: false,
+      isDropdownOpen: !popup.isDropdownOpen,
     });
   };
 
@@ -30,6 +41,7 @@ const usePopup = () => {
     setPopup({
       isNoteOpen: false,
       isNotificationOpen: false,
+      isDropdownOpen: false,
     });
   };
 
@@ -65,6 +77,7 @@ const usePopup = () => {
     closePopup,
     toggleNoteBox,
     toggleNotificationBox,
+    toggleDropdownMenu,
     notes,
     notifications,
     unreadNoteCount,

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -5,6 +5,7 @@ export const popupState = atom({
   default: {
     isNoteOpen: false,
     isNotificationOpen: false,
+    isDropdownOpen: false,
   },
 });
 


### PR DESCRIPTION
## 개요 🔎

Fixes #227, Fixes #225 

모바일 마이페이지, 헤더 버그 수정 작업을 했습니다.
마이페이지 정보 수정 버튼 활성화 부분은 pc버전은 작업을 모바일에도 반영할 예정입니다. (내일 아침 공유 예정)

## 작업사항 📝

* 모바일 마이페이지 정보수정 가운데로 오도록 너비 수정
* 헤더 드롭다운 메뉴 다른 영역 누르면 창 닫히도록 수정
* 프로젝트 리스트(마이페이지, 공개프로필)에 하트 반영 안 되던 부분 수정 

## 패키지 설치내용 📦

.