### PR TITLE
[fix] 로그인/로그아웃 시 렌더링 버그 수정

### DIFF
--- a/src/components/login/Welcome.tsx
+++ b/src/components/login/Welcome.tsx
@@ -7,6 +7,11 @@ import { useGlobalModal } from 'hooks';
 export default function Welcome() {
   const { closeModal } = useGlobalModal();
 
+  const handleModalClose = () => {
+    closeModal();
+    window.location.reload();
+  };
+
   return (
     <Container>
       <TopContainer>
@@ -16,7 +21,7 @@ export default function Welcome() {
           <SubText>Detto와 함께 즐거운 프로젝트 여정을 만들어보세요</SubText>
         </TextContainer>
       </TopContainer>
-      <ConfirmButton onClick={closeModal}>확인</ConfirmButton>
+      <ConfirmButton onClick={handleModalClose}>확인</ConfirmButton>
     </Container>
   );
 }

--- a/src/components/login/mobile/MobileWelcome.tsx
+++ b/src/components/login/mobile/MobileWelcome.tsx
@@ -8,6 +8,11 @@ import MobileConfirmButton from './MobileConfirmButton';
 export default function MobileWelcome() {
   const { closeModal } = useGlobalModal();
 
+  const handleModalClose = () => {
+    closeModal();
+    window.location.reload();
+  };
+
   return (
     <Container>
       <TopContainer>
@@ -17,7 +22,7 @@ export default function MobileWelcome() {
           <SubText>Detto와 함께 즐거운 프로젝트 여정을 만들어보세요</SubText>
         </TextContainer>
       </TopContainer>
-      <MobileConfirmButton onClick={closeModal} />
+      <MobileConfirmButton onClick={handleModalClose} />
     </Container>
   );
 }

--- a/src/components/mypage/LeftTab.tsx
+++ b/src/components/mypage/LeftTab.tsx
@@ -13,7 +13,7 @@ export interface LeftTabProps {
 
 const LeftTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
   const { isOpen, handleModalStateChange } = useModal(false);
-  const { handleLogoutClick } = useHeader();
+  const { withdrawalAccount } = useHeader();
 
   // 탭 활성화하는 함수
   const handleTabClick = (e: React.MouseEvent<HTMLLIElement>) => {
@@ -31,9 +31,9 @@ const LeftTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
 
     // 회원 탈퇴 시 db에서 삭제되는 부분 임시 주석처리
     // await deleteDoc(doc(firestore, 'users', currentUser.uid));
-    // deleteUser(currentUser).catch((err) => console.error(err));
-    // handleModalStateChange();
-    handleLogoutClick();
+    deleteUser(currentUser).catch((err) => console.error(err));
+    handleModalStateChange();
+    withdrawalAccount();
   };
 
   return (

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -35,6 +35,7 @@ const useHeader = () => {
       navigate('/', { replace: true });
       setIsLoggedIn(false);
       setUserInfo(defaultInfo);
+      window.location.reload();
     });
   };
 

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -2,7 +2,10 @@ import { authService } from 'apis/firebaseService';
 import { signOut } from 'firebase/auth';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { userInfoState } from '../recoil/atoms';
 import useAuth from './useAuth';
+import { defaultInfo } from './useUpdateProfile';
 
 // 메인 페이지에서 스크롤이 MAIN_SCROLL_Y 값 이상 되면 헤더의 배경색을 투명에서 하얀색으로 변경
 const MAIN_SCROLL_Y = 480;
@@ -11,6 +14,7 @@ const useHeader = () => {
   const [hideGradient, setHideGradient] = useState<boolean>(true);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [showDropwdown, setShowDropdown] = useState<boolean>(false);
+  const setUserInfo = useSetRecoilState(userInfoState);
   const localUser = useAuth();
 
   const navigate = useNavigate();
@@ -30,6 +34,7 @@ const useHeader = () => {
       localStorage.removeItem('user');
       navigate('/', { replace: true });
       setIsLoggedIn(false);
+      setUserInfo(defaultInfo);
     });
   };
 

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -33,10 +33,16 @@ const useHeader = () => {
     signOut(authService).then(() => {
       localStorage.removeItem('user');
       navigate('/', { replace: true });
-      setIsLoggedIn(false);
       setUserInfo(defaultInfo);
       window.location.reload();
     });
+  };
+
+  // 회원탈퇴
+  const withdrawalAccount = () => {
+    localStorage.removeItem('user');
+    setUserInfo(defaultInfo);
+    navigate('/', { replace: true });
   };
 
   // 모바일에서 드롭다운 메뉴 표시 여부
@@ -87,6 +93,7 @@ const useHeader = () => {
     handleDropdownClick,
     handleGoBackClick,
     closeDropdownMenu,
+    withdrawalAccount,
   };
 };
 

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -75,6 +75,7 @@ const useSocialLogin = () => {
       } else {
         // 기존 유저일 경우, 모달 닫기
         closeModal();
+        window.location.reload();
       }
     } catch (error) {
       console.error('error: ', error);

--- a/src/hooks/useUpdateProfile.ts
+++ b/src/hooks/useUpdateProfile.ts
@@ -110,7 +110,7 @@ const useUpdateProfile = () => {
 
 export default useUpdateProfile;
 
-const defaultInfo = {
+export const defaultInfo = {
   displayName: '',
   email: '' || null,
   photoURL: '',


### PR DESCRIPTION
## 개요 🔎

fix #233 

로그인/로그아웃 시의 렌더링 버그 해결을 위한  작업을 진행했습니다.
현재 배포 된 링크에서 로그인 시 바로 마이페이지, 새 글 쓰기에 접근할 수 없는 이슈 
로그아웃 후 다른 계정으로 로그인 한 뒤 마이페이지 갔을 때 이전 계정의 정보가 보여지는 이슈

프리뷰로 테스트해볼 예정입니다.

## 작업사항 📝

* 로그인/회원가입 시 모달창 닫힌 후 새로고침 추가
* 로그아웃 시 새로고침 추가
* 회원탈퇴 로직 수정
* 로그아웃/회원탈퇴 시 마이페이지에서 사용되는 userInfo state를 초기값으로 변경

## 패키지 설치내용 📦

.