### PR TITLE
[feat] 모바일 상세보기 Viewer, 제목 ellipsis 적용

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -165,9 +165,13 @@ const ContentCardTitle = styled.div`
   font-weight: 400;
   font-size: 1.125rem;
   line-height: 140%;
-  display: flex;
-  align-items: center;
   color: ${COLORS.black};
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 `;
 const ContentCardSubTextBox = styled.div`
   display: flex;

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -102,6 +102,8 @@ const MobileContentCardWrap = styled.div`
   margin: 0.9375rem 0;
 `;
 const ContentCardImgContainer = styled.div`
+  min-width: 4.5rem;
+  min-height: 4.5rem;
   width: 4.5rem;
   height: 4.5rem;
   margin-right: 1.4375rem;
@@ -117,6 +119,8 @@ const ContentCardContentsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.1875rem;
+  width: 100%;
+  overflow: hidden;
 `;
 const RecruitingIcon = styled.div`
   min-width: 2.8rem;
@@ -161,6 +165,10 @@ const ContentCardTitle = styled.div`
   line-height: 1.4375rem;
 
   color: #333d4b;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 const ContentCardSubTextBox = styled.div`
   display: flex;

--- a/src/components/common/mobile/MobileContainer.tsx
+++ b/src/components/common/mobile/MobileContainer.tsx
@@ -6,8 +6,7 @@ const MobileContainer = ({ children }: ContainerType) => {
 };
 
 const MobileContainerWrapper = styled.div`
-  width: 390px;
-  margin: 0 auto;
+  padding: 0 1rem;
   position: relative;
 `;
 

--- a/src/components/main/Calendar/ProjectDetail.tsx
+++ b/src/components/main/Calendar/ProjectDetail.tsx
@@ -37,20 +37,24 @@ const ProjectDetail = () => {
         </ProjectDetailSproutText>
         <ProjectDetailRow>
           <ProjectDetailLabel>프로젝트 이름</ProjectDetailLabel>
-          {selectedProject.title}
+          <ProjectDetailText>{selectedProject.title}</ProjectDetailText>
         </ProjectDetailRow>
         <ProjectDetailRow>
           <ProjectDetailLabel>기간</ProjectDetailLabel>
-          {getDate(selectedProject.startDate)} ~{' '}
-          {getDate(selectedProject.endDate)}
+          <ProjectDetailText>
+            {getDate(selectedProject.startDate)} ~{' '}
+            {getDate(selectedProject.endDate)}
+          </ProjectDetailText>
         </ProjectDetailRow>
         <ProjectDetailRow>
           <ProjectDetailLabel>포지션</ProjectDetailLabel>
-          {positionsNames.join(', ')}
+          <ProjectDetailText>{positionsNames.join(', ')}</ProjectDetailText>
         </ProjectDetailRow>
         <ProjectDetailRow>
           <ProjectDetailLabel>모집 마감일</ProjectDetailLabel>
-          {getDate(selectedProject.deadline)}
+          <ProjectDetailText>
+            {getDate(selectedProject.deadline)}
+          </ProjectDetailText>
         </ProjectDetailRow>
         <ProjectDetailinquiryAttentionBox>
           <ProjectDetailinquiryAttentionTextBox>
@@ -106,6 +110,15 @@ const ProjectDetailLabel = styled.div`
   font-weight: 400;
   margin-right: 1rem;
 `;
+
+const ProjectDetailText = styled.div`
+  color: #464646;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+`;
+
 const ProjectDetailSproutText = styled.div`
   display: flex;
   flex-direction: row;

--- a/src/components/main/Calendar/ProjectList.tsx
+++ b/src/components/main/Calendar/ProjectList.tsx
@@ -151,8 +151,6 @@ const ProjectListCardTextBox = styled.div`
 const ProjectListCardFindUser = styled.div`
   width: 268px;
   height: 14px;
-  font-family: 'Noto Sans CJK KR';
-  font-style: normal;
   font-weight: 400;
   font-size: 10px;
   line-height: 150%;
@@ -163,20 +161,18 @@ const ProjectListCardFindUser = styled.div`
 const ProjectListCardProjectName = styled.div`
   width: 268px;
   height: 24px;
-  font-family: 'Noto Sans CJK KR';
-  font-style: normal;
   font-weight: 500;
   font-size: 16px;
   line-height: 150%;
-  display: flex;
-  align-items: center;
   color: #464646;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 const ProjectListCardDate = styled.div`
   width: 268px;
   height: 15px;
-  font-family: 'Noto Sans KR';
-  font-style: normal;
   font-weight: 400;
   font-size: 10px;
   line-height: 150%;

--- a/src/components/projectDetail/mobile/MobileRecruitContentArea.tsx
+++ b/src/components/projectDetail/mobile/MobileRecruitContentArea.tsx
@@ -1,11 +1,21 @@
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 
+import { Viewer } from '@toast-ui/react-editor';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
+import Prism from 'prismjs';
+
 const MobileRecruitContentArea = ({ content }: any) => {
   return (
     <MobileRecruitContentContainer>
       <MobileRecruitContentTitle>모집안내</MobileRecruitContentTitle>
-      <MobileRecruitContentText>{content}</MobileRecruitContentText>
+      <MobileRecruitContentText>
+        <Viewer
+          initialValue={content}
+          plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
+        />
+      </MobileRecruitContentText>
     </MobileRecruitContentContainer>
   );
 };
@@ -29,11 +39,7 @@ const MobileRecruitContentText = styled.div`
   width: 100%;
   min-height: 183px;
   height: 100%;
-  font-size: 10px;
-  line-height: 140%;
   background-color: ${COLORS.white};
-  color: ${COLORS.gray800};
-
   margin-top: 6px;
   padding: 13px 15px;
 `;

--- a/src/components/writepage/mobile/WritePageMobileFooter.tsx
+++ b/src/components/writepage/mobile/WritePageMobileFooter.tsx
@@ -33,10 +33,8 @@ const WritePageMobileFooterContainer = styled.div`
   gap: 1.5rem;
 `;
 const WritePageMobileFooterEditBox = styled.div`
-  width: 22.25rem;
+  width: 100%;
   height: 25rem;
-  border: 1px solid ${COLORS.gray100};
-  border-radius: 0.25rem;
 `;
 const WritePageMobileFooterCompleatedButton = styled.button`
   width: 17rem;

--- a/src/components/writepage/mobile/WritePageMobileHeader.tsx
+++ b/src/components/writepage/mobile/WritePageMobileHeader.tsx
@@ -32,7 +32,7 @@ const WritePageMobileHeaderContainer = styled.div`
   justify-content: center;
 `;
 const WritePageMobileHeaderInput = styled.input`
-  width: 22.25rem;
+  width: 100%;
   height: 2.8125rem;
   padding: 0.625rem 1.25rem;
   background: ${COLORS.white};

--- a/src/components/writepage/mobile/WritePageMobileThumbnail.tsx
+++ b/src/components/writepage/mobile/WritePageMobileThumbnail.tsx
@@ -52,7 +52,7 @@ const WritePageMobileThumbnailContainer = styled.div`
   justify-content: center;
 `;
 const WritePageMobileThumbnailInput = styled.input`
-  width: 14.5rem;
+  flex: 1;
   height: 2.75rem;
   background-color: ${COLORS.white};
   border: 1px solid ${COLORS.gray100};


### PR DESCRIPTION
## 개요 🔎

- 모바일 상세보기 페이지 Toast UI Viewer를 적용했습니다.
- 제목이 길어질 경우 ellipsis를 적용했습니다.

## 작업사항 📝

- ContentArea 컴포넌트에 Viewer 추가
- Project List, Content Card, Calendar 제목 ellipsis 추가

## 패키지 설치내용 📦

.