### PR TITLE
[fix] 디테일 페이지 toast ui editor 수정시 바로 값 안바뀌는 버그 수정

### DIFF
--- a/src/components/projectDetail/ContentArea.tsx
+++ b/src/components/projectDetail/ContentArea.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 
@@ -7,14 +9,26 @@ import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
 import Prism from 'prismjs';
 
 const ContentArea = ({ projectData }: any) => {
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoaded(true);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <RecruitContentsContainer>
       <ContentTitle>모집 안내</ContentTitle>
       <ContentWrapper>
-        <Viewer
-          initialValue={projectData.content}
-          plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
-        />
+        {isLoaded && (
+          <Viewer
+            initialValue={projectData?.content}
+            plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
+          />
+        )}
       </ContentWrapper>
     </RecruitContentsContainer>
   );
@@ -39,4 +53,25 @@ const ContentWrapper = styled.div`
   background-color: ${COLORS.white};
   padding: 2.5rem;
   font-size: 1.25rem;
+  .toastui-editor-contents p {
+    font-size: 1.2rem;
+  }
+  .toastui-editor-contents h1 {
+    font-size: 2.4rem;
+  }
+  .toastui-editor-contents h2 {
+    font-size: 2.1rem;
+  }
+  .toastui-editor-contents h3 {
+    font-size: 1.9rem;
+  }
+  .toastui-editor-contents h4 {
+    font-size: 1.7rem;
+  }
+  .toastui-editor-contents h5 {
+    font-size: 1.5rem;
+  }
+  .toastui-editor-contents h6 {
+    font-size: 1.3rem;
+  }
 `;

--- a/src/components/projectDetail/mobile/MobileRecruitContentArea.tsx
+++ b/src/components/projectDetail/mobile/MobileRecruitContentArea.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 
@@ -7,14 +9,26 @@ import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
 import Prism from 'prismjs';
 
 const MobileRecruitContentArea = ({ content }: any) => {
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoaded(true);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <MobileRecruitContentContainer>
       <MobileRecruitContentTitle>모집안내</MobileRecruitContentTitle>
       <MobileRecruitContentText>
-        <Viewer
-          initialValue={content}
-          plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
-        />
+        {isLoaded && (
+          <Viewer
+            initialValue={content}
+            plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
+          />
+        )}
       </MobileRecruitContentText>
     </MobileRecruitContentContainer>
   );


### PR DESCRIPTION
## 개요 :mag_right:

- close #258 
- 디테일 페이지에서 Toast Ui Editor 의 Viewer 컴포넌트가 글 수정시 수정한 Content 값으로 제대로 안나오는 렌더링 문제 해결을 위한 이슈
- 디테일 페이지 Toast Ui Editor 기본 폰트 사이즈 변경

## 작업사항 :pencil:

- 디테일 페이지 ContentArea 부분 렌더링 늦추기
- 디테일 페이지 Toast Ui Editor CSS 세부 조정을 통해 기본 폰트 사이즈 키우기

## 패키지 설치내용 :package: