### PR TITLE
[feat] 회원탈퇴 기능 구현

### DIFF
--- a/src/apis/userService.ts
+++ b/src/apis/userService.ts
@@ -7,15 +7,19 @@ import {
   collection,
   query,
   limit,
+  where,
 } from 'firebase/firestore';
 
 /**
- * 파이어베이스 users 컬렉션에서 모든 사용자의 정보를 조회
- * @returns 모든 사용자의 정보를 담은 배열
+ * 파이어베이스 users 컬렉션에서 활성화된 사용자의 정보를 조회
+ * @returns 활성화된 사용자의 정보를 담은 배열
  */
-
-export const firebaseAllUsersRequest = async () => {
-  const q = query(collection(firestore, 'users'), limit(20));
+export const firebaseActiveUsersRequest = async () => {
+  const q = query(
+    collection(firestore, 'users'),
+    where('isActive', '==', true),
+    limit(20),
+  );
   const querySnapshot = await getDocs(q);
   return querySnapshot.docs.map((doc) => doc.data());
 };

--- a/src/components/main/findUsers/FindUserSlider.tsx
+++ b/src/components/main/findUsers/FindUserSlider.tsx
@@ -8,7 +8,7 @@ import Junior from 'assets/images/junior.png';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { staleTime } from 'utils/staleTime';
-import { firebaseAllUsersRequest } from 'apis/userService';
+import { firebaseActiveUsersRequest } from 'apis/userService';
 import COLORS from 'assets/styles/colors';
 
 const settings = {
@@ -23,7 +23,7 @@ const settings = {
 const FindUserSlider = ({ tap }: { tap: string }) => {
   const { data: users } = useQuery({
     queryKey: ['users'],
-    queryFn: firebaseAllUsersRequest,
+    queryFn: firebaseActiveUsersRequest,
     staleTime: staleTime.users,
   });
 

--- a/src/components/main/findUsers/MobileFindUserSlider.tsx
+++ b/src/components/main/findUsers/MobileFindUserSlider.tsx
@@ -8,7 +8,7 @@ import Junior from 'assets/images/junior.png';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { staleTime } from 'utils/staleTime';
-import { firebaseAllUsersRequest } from 'apis/userService';
+import { firebaseActiveUsersRequest } from 'apis/userService';
 import COLORS from 'assets/styles/colors';
 import defaultProfile from 'assets/images/default_profile.jpg';
 
@@ -24,7 +24,7 @@ const settings = {
 const MobileFindUserSlider = ({ tap }: { tap: string }) => {
   const { data: users } = useQuery({
     queryKey: ['users'],
-    queryFn: firebaseAllUsersRequest,
+    queryFn: firebaseActiveUsersRequest,
     staleTime: staleTime.users,
   });
 

--- a/src/components/mypage/LeftTab.tsx
+++ b/src/components/mypage/LeftTab.tsx
@@ -29,9 +29,9 @@ const LeftTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
       return;
     }
 
-    // 회원 탈퇴 시 users 컬렉션의 isWithdrawal 필드를 true로 변경
+    // 회원 탈퇴 시 users 컬렉션의 isActive 필드를 false로 변경
     await updateDoc(doc(firestore, 'users', currentUser.uid), {
-      isWithdrawn: true,
+      isActive: false,
     });
     deleteUser(currentUser).catch((err) => console.error(err));
     handleModalStateChange();

--- a/src/components/mypage/LeftTab.tsx
+++ b/src/components/mypage/LeftTab.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import ConfirmAlert from 'components/common/ConfirmAlert';
 import { authService, firestore } from 'apis/firebaseService';
 import COLORS from 'assets/styles/colors';
-import { deleteDoc, doc } from 'firebase/firestore';
+import { deleteDoc, doc, updateDoc } from 'firebase/firestore';
 
 export interface LeftTabProps {
   activeTab: string;
@@ -29,8 +29,10 @@ const LeftTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
       return;
     }
 
-    // 회원 탈퇴 시 db에서 삭제되는 부분 임시 주석처리
-    // await deleteDoc(doc(firestore, 'users', currentUser.uid));
+    // 회원 탈퇴 시 users 컬렉션의 isWithdrawal 필드를 true로 변경
+    await updateDoc(doc(firestore, 'users', currentUser.uid), {
+      isWithdrawn: true,
+    });
     deleteUser(currentUser).catch((err) => console.error(err));
     handleModalStateChange();
     withdrawalAccount();

--- a/src/components/popup/CustomButton.tsx
+++ b/src/components/popup/CustomButton.tsx
@@ -5,21 +5,23 @@ type ButtonProps = {
   label: string;
   onClick: () => void;
   disabled?: boolean;
+  color?: string;
 };
 
 export default function CustomButton({
   label,
   onClick,
   disabled,
+  color,
 }: ButtonProps) {
   return (
-    <Button onClick={onClick} disabled={disabled}>
+    <Button onClick={onClick} disabled={disabled} color={color}>
       {label}
     </Button>
   );
 }
 
-const Button = styled.button`
+const Button = styled.button<{ color?: string }>`
   width: 100%;
   height: 3.75rem;
 
@@ -30,11 +32,16 @@ const Button = styled.button`
   align-items: center;
   justify-content: center;
 
-  color: ${COLORS.white};
-  background-color: ${COLORS.violetB400};
+  color: ${({ color }) => (color === 'gray' ? COLORS.gray800 : COLORS.white)};
+  background-color: ${({ color }) =>
+    color === 'gray' ? COLORS.gray100 : COLORS.violetB400};
   border-radius: 1rem;
 
-  &:hover {
-    background-color: ${COLORS.violetB300};
+  :hover {
+    background-color: ${({ color }) =>
+      color === 'gray' ? COLORS.gray100 : COLORS.violetB300};
+  }
+  :disabled {
+    background-color: ${COLORS.gray100};
   }
 `;

--- a/src/components/popup/ReadInboxNote.tsx
+++ b/src/components/popup/ReadInboxNote.tsx
@@ -47,7 +47,16 @@ export default function ReadInboxNote({ data }: { data: Note }) {
       </HeaderContainer>
       <TitleText>{data.title}</TitleText>
       <ContentText>{data.content}</ContentText>
-      <CustomButton label="답장하기" onClick={handleReplyButtonClick} />
+      {sender?.isWithdrawn ? (
+        <CustomButton
+          label="탈퇴한 회원입니다."
+          onClick={handleReplyButtonClick}
+          color="gray"
+          disabled
+        />
+      ) : (
+        <CustomButton label="답장하기" onClick={handleReplyButtonClick} />
+      )}
     </Container>
   );
 }

--- a/src/components/popup/ReadInboxNote.tsx
+++ b/src/components/popup/ReadInboxNote.tsx
@@ -47,7 +47,7 @@ export default function ReadInboxNote({ data }: { data: Note }) {
       </HeaderContainer>
       <TitleText>{data.title}</TitleText>
       <ContentText>{data.content}</ContentText>
-      {sender?.isWithdrawn ? (
+      {!sender?.isActive ? (
         <CustomButton
           label="탈퇴한 회원입니다."
           onClick={handleReplyButtonClick}

--- a/src/components/popup/mobile/MobileCustomButton.tsx
+++ b/src/components/popup/mobile/MobileCustomButton.tsx
@@ -5,21 +5,23 @@ type ButtonProps = {
   label: string;
   onClick: () => void;
   disabled?: boolean;
+  color?: string;
 };
 
 export default function MobileCustomButton({
   label,
   onClick,
   disabled,
+  color,
 }: ButtonProps) {
   return (
-    <Button onClick={onClick} disabled={disabled}>
+    <Button onClick={onClick} disabled={disabled} color={color}>
       {label}
     </Button>
   );
 }
 
-const Button = styled.button`
+const Button = styled.button<{ color?: string }>`
   width: 100%;
   height: 3.25rem;
 
@@ -30,11 +32,16 @@ const Button = styled.button`
   align-items: center;
   justify-content: center;
 
-  color: ${COLORS.white};
-  background-color: ${COLORS.violetB400};
+  color: ${({ color }) => (color === 'gray' ? COLORS.gray800 : COLORS.white)};
+  background-color: ${({ color }) =>
+    color === 'gray' ? COLORS.gray100 : COLORS.violetB400};
   border-radius: 1rem;
 
-  &:hover {
-    background-color: ${COLORS.violetB300};
+  :hover {
+    background-color: ${({ color }) =>
+      color === 'gray' ? COLORS.gray100 : COLORS.violetB300};
+  }
+  :disabled {
+    background-color: ${COLORS.gray100};
   }
 `;

--- a/src/components/popup/mobile/MobileReadInboxNote.tsx
+++ b/src/components/popup/mobile/MobileReadInboxNote.tsx
@@ -53,7 +53,7 @@ export default function MobileReadInboxNote({ data }: { data: Note }) {
       </MobileHeaderContainer>
       <MobileTitleText>{data.title}</MobileTitleText>
       <MobileContentText>{data.content}</MobileContentText>
-      {sender?.isWithdrawn ? (
+      {!sender?.isActive ? (
         <MobileCustomButton
           label="탈퇴한 회원입니다."
           onClick={handleReplyButtonClick}

--- a/src/components/popup/mobile/MobileReadInboxNote.tsx
+++ b/src/components/popup/mobile/MobileReadInboxNote.tsx
@@ -53,7 +53,16 @@ export default function MobileReadInboxNote({ data }: { data: Note }) {
       </MobileHeaderContainer>
       <MobileTitleText>{data.title}</MobileTitleText>
       <MobileContentText>{data.content}</MobileContentText>
-      <MobileCustomButton label="답장하기" onClick={handleReplyButtonClick} />
+      {sender?.isWithdrawn ? (
+        <MobileCustomButton
+          label="탈퇴한 회원입니다."
+          onClick={handleReplyButtonClick}
+          color="gray"
+          disabled
+        />
+      ) : (
+        <MobileCustomButton label="답장하기" onClick={handleReplyButtonClick} />
+      )}
     </MobileContainer>
   );
 }

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -26,6 +26,7 @@ const initializeUserCollections = (user: User) => {
       plannerStack: [],
       positions: [],
       isJunior: false,
+      isActive: true,
     }),
     setDoc(doc(firestore, 'myprojects', user.uid), {
       likedProjects: [],

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -60,7 +60,7 @@ const PublicProfilePage = () => {
   if (!userInfoData) return null;
 
   // 탈퇴한 회원일 경우 메세지 표시
-  if (userInfoData.isWithdrawn) {
+  if (!userInfoData.isActive) {
     if (isMobile)
       return <NoDataMessage mobile>탈퇴한 회원입니다 :/</NoDataMessage>;
     return <NoDataMessage>탈퇴한 회원입니다 :/</NoDataMessage>;

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -21,6 +21,7 @@ const PublicProfilePage = () => {
   const { activeProjectTab, handleProjectTabClick, setActiveProjectTab } =
     useProjectList();
   const { openModalWithData, openModal } = useGlobalModal();
+  const isMobile = useIsMobile();
 
   const { data: userInfoData }: any = useQuery({
     queryKey: ['users', id],
@@ -56,9 +57,16 @@ const PublicProfilePage = () => {
     setActiveProjectTab('currentProjects');
   }, []);
 
-  const isMobile = useIsMobile();
+  if (!userInfoData) return null;
 
-  if (isMobile && userInfoData) {
+  // 탈퇴한 회원일 경우 메세지 표시
+  if (userInfoData.isWithdrawn) {
+    if (isMobile)
+      return <NoDataMessage mobile>탈퇴한 회원입니다 :/</NoDataMessage>;
+    return <NoDataMessage>탈퇴한 회원입니다 :/</NoDataMessage>;
+  }
+
+  if (isMobile) {
     return (
       <MobilePublicProfilePage
         userInfoData={userInfoData}
@@ -244,23 +252,22 @@ const UserInfoValue = styled.div`
   color: #828282; //색상표에 없는데 사용되고 있음. 문의하기
 `;
 
-const UserSkillStackDiv = styled.div`
-  display: flex;
-  align-items: center;
-
-  height: 2rem;
-  padding: 0 0.75rem;
-  background-color: ${COLORS.gray100};
-  border-radius: 2rem;
-
-  font-size: 0.75rem;
-  color: ${COLORS.black};
-
-  cursor: default;
-`;
-
 const UserProjectWrapper = styled.div`
   margin-top: 7.875rem;
   font-size: 1.25rem;
   font-weight: 500;
+`;
+
+const NoDataMessage = styled.div<{ mobile?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 75vh;
+
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: ${COLORS.gray300};
 `;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -9,6 +9,7 @@ interface UserInfo {
   plannerStack: string[];
   designerStack: string[];
   developerStack: string[];
+  isWithdrawn?: boolean;
 }
 
 interface Note {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -9,7 +9,7 @@ interface UserInfo {
   plannerStack: string[];
   designerStack: string[];
   developerStack: string[];
-  isWithdrawn?: boolean;
+  isActive?: boolean;
 }
 
 interface Note {


### PR DESCRIPTION
## 개요 🔎

회원 탈퇴 기능을 구현했습니다.

## 작업사항 📝

- 사용자 문서에 isActive 필드를 추가했습니다.
- 회원 탈퇴 시 isActive를 false로 수정했습니다.
- 탈퇴한 유저의 공개프로필에 접근 시 에러 메세지를 추가했습니다.
- 탈퇴한 유저의 쪽지에 답장하기 버튼을 비활성화 했습니다.

## 패키지 설치내용 📦

.