### PR TITLE
[fix] 유효성 검사 실패 시 버튼 disabled되는 에러 수정

### DIFF
--- a/src/components/popup/ReplyNote.tsx
+++ b/src/components/popup/ReplyNote.tsx
@@ -91,7 +91,6 @@ export default function ReplyNote({ data }: { data: Note }) {
           label="쪽지를 보낼게요"
           onClick={() => {
             handleSendButtonClick();
-            setDisabled(true);
           }}
           disabled={disabled}
         />

--- a/src/components/popup/SendNote.tsx
+++ b/src/components/popup/SendNote.tsx
@@ -91,7 +91,6 @@ export default function SendNote({ data }: { data: Note }) {
           label="쪽지를 보낼게요"
           onClick={() => {
             handleSendButtonClick();
-            setDisabled(true);
           }}
           disabled={disabled}
         />


### PR DESCRIPTION
## 개요 🔎

Closes #305 
유효성 검사 실패 시 쪽지 보내기 버튼이 disabled 되는 에러를 수정했습니다.

## 작업사항 📝

쪽지 보내기 버튼의 onClick 이벤트에서 setDisabled 제거

## 패키지 설치내용 📦

.