### PR TITLE
[feat] 팀원찾기, 글 작성&수정 Amplitude 적용

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -5,6 +5,7 @@ import { firebaseLikeProjectUpdateRequest } from 'apis/boardService';
 import { useAuth } from 'hooks';
 import { getDate } from 'utils/date';
 import { concatSkills } from 'utils/skills';
+import { getCurrentPathName, logEvent } from 'utils/amplitude';
 import { EditType } from 'types/write/writeType';
 import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 import defaultThumbnail from 'assets/images/thumbnail_small.jpg';
@@ -62,6 +63,11 @@ const ContentCard = ({
   const handleUpdateLike = useCallback(() => {
     setIsLike(!isLike);
     updateLikeMutate();
+    logEvent('Button Click', {
+      from: getCurrentPathName(),
+      to: 'none',
+      name: 'like',
+    });
   }, [isLike]);
 
   useEffect(() => {

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -4,6 +4,7 @@ import { updateRecruiting } from 'apis/postDetail';
 import { firebaseLikeProjectUpdateRequest } from 'apis/boardService';
 import { useAuth } from 'hooks';
 import { getDate } from 'utils/date';
+import { getCurrentPathName, logEvent } from 'utils/amplitude';
 import { EditType } from 'types/write/writeType';
 import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 import defaultThumbnail from 'assets/images/thumbnail_mobile.jpg';
@@ -59,6 +60,11 @@ const MobileContentCard = ({
   const handleUpdateLike = useCallback(() => {
     setIsLike(!isLike);
     updateLikeMutate();
+    logEvent('Button Click', {
+      from: getCurrentPathName(),
+      to: 'none',
+      name: 'like',
+    });
   }, [isLike, updateLikeMutate]);
 
   useEffect(() => {

--- a/src/hooks/useEditBoard.ts
+++ b/src/hooks/useEditBoard.ts
@@ -3,8 +3,8 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { firebaseEditProjectRequest } from 'apis/boardService';
 import { useModal, useToastPopup } from 'hooks';
-import Resizer from 'react-image-file-resizer';
 import { EditType } from 'types/write/writeType';
+import { logEvent } from 'utils/amplitude';
 import {
   contentValidation,
   deadlineValidation,
@@ -13,6 +13,7 @@ import {
   stackValidation,
   titleValidation,
 } from 'utils/validation';
+import Resizer from 'react-image-file-resizer';
 
 const useEditBoard = () => {
   const { state } = useLocation();
@@ -103,6 +104,11 @@ const useEditBoard = () => {
     if (!params.id) {
       return;
     }
+    logEvent('Button Click', {
+      from: 'edit',
+      to: 'project_detail',
+      name: 'project_edit',
+    });
     if (!editThumbnail) {
       editProjectRequest(imageRef.current.files[0]);
       return;
@@ -113,6 +119,11 @@ const useEditBoard = () => {
 
   const handleAddThumbnailImage = useCallback(() => {
     imageRef.current.click();
+    logEvent('Button Click', {
+      from: 'edit',
+      to: 'project_detail',
+      name: 'add_thumbnail_image',
+    });
   }, [imageRef]);
 
   const handleAddThumbnailImageChange = () => {

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from 'hooks';
 import { firebaseInfinityScrollProjectDataRequest } from 'apis/boardService';
 import { firebaseFindMyInterestRequest } from 'apis/userService';
-import { useAuth } from 'hooks';
 import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 import { EditType } from 'types/write/writeType';
+import { logEvent, getCurrentPathName } from 'utils/amplitude';
 
 const useFindProject = () => {
   const navigate = useNavigate();
@@ -47,13 +48,28 @@ const useFindProject = () => {
 
   const handleCategoryClick = (e: any) => {
     setCategory(e.target.name);
+    logEvent('Button Click', {
+      from: getCurrentPathName(),
+      to: 'none',
+      name: `category_${e.target.name}`,
+    });
   };
 
   const handleToggleClick = () => {
     setToggle((prev) => !prev);
+    logEvent('Button Click', {
+      from: getCurrentPathName(),
+      to: 'none',
+      name: 'toggle_recruitment',
+    });
   };
 
   const handleNavigateToProjectDetail = (path: string) => () => {
+    logEvent('Button Click', {
+      from: getCurrentPathName(),
+      to: 'project_detail',
+      name: 'content_card',
+    });
     navigate(`/project/${path}`);
   };
 

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -2,8 +2,8 @@ import { useState, useRef, useCallback, ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth, useModal, useToastPopup } from 'hooks';
 import { firebaseCreateProjectRequest } from 'apis/boardService';
-import Resizer from 'react-image-file-resizer';
 import { WriteType } from 'types/write/writeType';
+import { getCurrentPathName, logEvent } from 'utils/amplitude';
 import {
   titleValidation,
   contentValidation,
@@ -12,6 +12,7 @@ import {
   deadlineValidation,
   stackValidation,
 } from './../utils/validation';
+import Resizer from 'react-image-file-resizer';
 
 const useWrite = () => {
   const navigate = useNavigate();
@@ -98,6 +99,11 @@ const useWrite = () => {
         resizedImage,
         uid,
       );
+      logEvent('Button Click', {
+        from: getCurrentPathName(),
+        to: 'project_detail',
+        name: 'write_project',
+      });
       navigate(`/project/${docId}`, {
         replace: true,
       });
@@ -110,6 +116,11 @@ const useWrite = () => {
 
   const handleAddThumbnailImage = useCallback(() => {
     imageRef.current.click();
+    logEvent('Button Click', {
+      from: getCurrentPathName(),
+      to: 'none',
+      name: 'add_thumbnail_image',
+    });
   }, [imageRef]);
 
   const handleAddThumbnailImageChange = () => {

--- a/src/pages/FindProjectPage.tsx
+++ b/src/pages/FindProjectPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import { useFindProject, useIsMobile } from 'hooks';
 import WebContainer from 'components/common/WebContainer';
 import FindProjectHeader from 'components/findproject/FindProjectHeader';
@@ -7,7 +8,6 @@ import FindProjectList from 'components/findproject/FindProjectList';
 import FindProjectMobileHeader from 'components/findproject/mobile/FindProjectMobileHeader';
 import FindProjectMobileList from 'components/findproject/mobile/FindProjectMobileList';
 import styled from '@emotion/styled';
-import { Helmet } from 'react-helmet-async';
 
 const FindProjectPage = () => {
   const {
@@ -21,6 +21,7 @@ const FindProjectPage = () => {
     handleNavigateToProjectDetail,
   } = useFindProject();
   const isMobile = useIsMobile();
+
   const { state: categoryFromFooter } = useLocation();
 
   // 푸터에서 클릭한 경우 카테고리 지정


### PR DESCRIPTION
## 개요 :mag_right:

팀원찾기 페이지와 글 작성 수정 페이지에 유저 사용성 체크를 위한 Amplitude 적용

## 작업사항 :pencil:

- 글 작성 & 수정 버튼 클릭 로직에 Amplitude 적용
- 팀원 찾기 페이지 카테고리, 토글버튼, 좋아요버튼, content card에 Amplitude 적용

## 패키지 설치내용 :package: