### PR TITLE
[fix] react query 에러 해결 & staleTime 조정

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState, memo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateRecruiting } from 'apis/postDetail';
 import { firebaseLikeProjectUpdateRequest } from 'apis/boardService';
-import { useAuth } from 'hooks';
+import { useAuth, useGlobalModal } from 'hooks';
 import { getDate } from 'utils/date';
 import { concatSkills } from 'utils/skills';
 import { getCurrentPathName, logEvent } from 'utils/amplitude';
@@ -40,6 +40,7 @@ const ContentCard = ({
   const [isLike, setIsLike] = useState<boolean>(false);
   const stacks = concatSkills(plannerStack, designerStack, developerStack);
   const queryClient = useQueryClient();
+  const { openModal } = useGlobalModal();
 
   const { mutate: updateRecruitingMutate } = useMutation(
     () => updateRecruiting(id as string, false),
@@ -61,6 +62,10 @@ const ContentCard = ({
   );
 
   const handleUpdateLike = useCallback(() => {
+    if (!uid) {
+      openModal('login', 0);
+      return;
+    }
     setIsLike(!isLike);
     updateLikeMutate();
     logEvent('Button Click', {
@@ -68,7 +73,7 @@ const ContentCard = ({
       to: 'none',
       name: 'like',
     });
-  }, [isLike]);
+  }, [isLike, updateLikeMutate, uid]);
 
   useEffect(() => {
     const today = Date.now();

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateRecruiting } from 'apis/postDetail';
 import { firebaseLikeProjectUpdateRequest } from 'apis/boardService';
-import { useAuth } from 'hooks';
+import { useAuth, useGlobalModal } from 'hooks';
 import { getDate } from 'utils/date';
 import { getCurrentPathName, logEvent } from 'utils/amplitude';
 import { EditType } from 'types/write/writeType';
@@ -38,6 +38,7 @@ const MobileContentCard = ({
   const idList: any[] = [];
   const queryClient = useQueryClient();
   const today = new Date().getTime();
+  const { openModal } = useGlobalModal();
 
   const { mutate: updateRecruitingMutate } = useMutation(
     () => updateRecruiting(id as string, false),
@@ -58,6 +59,10 @@ const MobileContentCard = ({
   );
 
   const handleUpdateLike = useCallback(() => {
+    if (!uid) {
+      openModal('login', 0);
+      return;
+    }
     setIsLike(!isLike);
     updateLikeMutate();
     logEvent('Button Click', {
@@ -65,7 +70,7 @@ const MobileContentCard = ({
       to: 'none',
       name: 'like',
     });
-  }, [isLike, updateLikeMutate]);
+  }, [isLike, updateLikeMutate, uid]);
 
   useEffect(() => {
     if (today > deadline) {

--- a/src/components/projectDetail/ApplyModal/ApplyModal.tsx
+++ b/src/components/projectDetail/ApplyModal/ApplyModal.tsx
@@ -13,6 +13,7 @@ import ApplyPositionArea from './ApplyPositionArea';
 import ValidationToastPopup from 'components/common/ValidationToastPopup';
 import COLORS from 'assets/styles/colors';
 import MobileAlert from 'components/common/mobile/MobileAlert';
+import { staleTime } from 'utils/staleTime';
 
 interface props {
   isOpen: boolean;
@@ -39,6 +40,8 @@ const ApplyModal = ({ isOpen, message, onClickEvent, pid }: props) => {
   const { data: userData } = useQuery({
     queryKey: ['users', uid],
     queryFn: () => findWithCollectionName('users', uid),
+    staleTime: staleTime.users,
+    enabled: !!uid,
   });
 
   //지원한 포지션에 맞는 스택 가져오기 위한 스위치문

--- a/src/components/projectDetail/ApplyModal/ApplyModalButtonArea.tsx
+++ b/src/components/projectDetail/ApplyModal/ApplyModalButtonArea.tsx
@@ -5,6 +5,7 @@ import COLORS from 'assets/styles/colors';
 import { useIsMobile, useNotification } from 'hooks';
 import { useCallback } from 'react';
 import { AiOutlineClose } from 'react-icons/ai';
+import { staleTime } from 'utils/staleTime';
 
 interface props {
   userData: any;
@@ -38,6 +39,8 @@ const ApplyModalButtonArea = ({
   const { data: projectData } = useQuery({
     queryKey: ['post', pid],
     queryFn: () => findWithCollectionName('post', pid),
+    staleTime: staleTime.project,
+    enabled: !!pid,
   });
 
   // 글쓴이에게 지원 알림 보내기

--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -7,6 +7,7 @@ import { findWithCollectionName } from 'apis/findWithCollectionName';
 import { useAuth, useGlobalModal } from 'hooks';
 import COLORS from 'assets/styles/colors';
 import { amplitudeToNoneButtonClick } from 'utils/amplitude';
+import { staleTime } from 'utils/staleTime';
 
 const Likes = ({ pid, version = 'web' }: any) => {
   const { uid } = useAuth();
@@ -29,11 +30,15 @@ const Likes = ({ pid, version = 'web' }: any) => {
   const { data: myProjects } = useQuery({
     queryKey: ['myProjects', uid],
     queryFn: () => findWithCollectionName('myprojects', uid),
+    staleTime: staleTime.myProjects,
+    enabled: !!uid,
   });
 
   const { data: projectLike } = useQuery({
     queryKey: ['post', pid],
     queryFn: () => findWithCollectionName('post', pid),
+    staleTime: staleTime.likedProjects,
+    enabled: !!pid,
   });
 
   const [countLike, setCountLike] = useState(projectLike?.like);

--- a/src/components/projectDetail/Share.tsx
+++ b/src/components/projectDetail/Share.tsx
@@ -140,6 +140,7 @@ const ShareBox = styled.div`
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  cursor: pointer;
 `;
 
 const ShareLinkButton = styled.button`

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -7,6 +7,7 @@ import { firebaseFindMyInterestRequest } from 'apis/userService';
 import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 import { EditType } from 'types/write/writeType';
 import { logEvent, getCurrentPathName } from 'utils/amplitude';
+import { staleTime } from 'utils/staleTime';
 
 const useFindProject = () => {
   const navigate = useNavigate();
@@ -21,6 +22,7 @@ const useFindProject = () => {
   const { data: likedProjects } = useQuery({
     queryKey: ['likedProjects', uid],
     queryFn: () => firebaseFindMyInterestRequest(uid),
+    staleTime: staleTime.likedProjects,
     enabled: !!uid,
   });
 

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -18,9 +18,11 @@ const useFindProject = () => {
   const [category, setCategory] = useState<string>('planner');
   const [toggle, setToggle] = useState<boolean>(false);
 
-  const { data: likedProjects } = useQuery(['likedProjects', uid], () =>
-    firebaseFindMyInterestRequest(uid),
-  );
+  const { data: likedProjects } = useQuery({
+    queryKey: ['likedProjects', uid],
+    queryFn: () => firebaseFindMyInterestRequest(uid),
+    enabled: !!uid,
+  });
 
   useEffect(() => {
     firebaseInfinityScrollProjectDataRequest(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,6 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       cacheTime: 1000 * 60 * 60 * 24, // 24시간
-      staleTime: 1000 * 5, // 5초
     },
   },
 });

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -32,6 +32,7 @@ const MyPage = () => {
     queryKey: ['myProjects', uid],
     queryFn: getUserProjectList,
     staleTime: staleTime.myProjects,
+    enabled: !!uid,
   });
 
   useEffect(() => {

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -23,6 +23,7 @@ import styled from '@emotion/styled';
 import { Helmet } from 'react-helmet-async';
 import { useEffect } from 'react';
 import { getCurrentPathName, logEvent } from 'utils/amplitude';
+import { staleTime } from 'utils/staleTime';
 
 const ProjectDetailPage = () => {
   const params = useParams();
@@ -34,6 +35,8 @@ const ProjectDetailPage = () => {
   const { data: projectData } = useQuery({
     queryKey: ['post', pid],
     queryFn: () => findWithCollectionName('post', pid),
+    staleTime: staleTime.project,
+    enabled: !!pid,
   });
 
   const { uid } = useAuth(); // 현재 사용자
@@ -43,12 +46,15 @@ const ProjectDetailPage = () => {
   const { data: userData } = useQuery({
     queryKey: ['users', writer],
     queryFn: () => findWithCollectionName('users', writer),
+    staleTime: staleTime.user,
+    enabled: !!writer,
   });
 
   // 현재 유저가 프로젝트 지원자 인가 조회
   const { data: isApplicant } = useQuery({
     queryKey: ['post', projectData?.applicants],
     queryFn: () => firebaseGetIsApplicantRequest(pid, uid),
+    staleTime: staleTime.project,
   });
 
   const queryClient = useQueryClient();

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -34,13 +34,14 @@ const PublicProfilePage = () => {
   const { data: userInfoData }: any = useQuery({
     queryKey: ['users', id],
     queryFn: getUserInfoData,
-    staleTime: staleTime.users,
+    staleTime: staleTime.user,
   });
 
   const { data: userProjectListsData }: any = useQuery({
     queryKey: ['myProjects', id],
     queryFn: getUserProjectList,
     staleTime: staleTime.myProjects,
+    enabled: !!id,
   });
 
   const handleSendNoteButtonClick = () => {

--- a/src/utils/staleTime.ts
+++ b/src/utils/staleTime.ts
@@ -3,9 +3,11 @@ export const staleTime = {
   outboxNotes: 1000 * 60 * 1, // 1분 (로그인한 사용자의 보낸 쪽지)
   notifications: 1000 * 60 * 1, // 1분 (로그인한 사용자의 받은 알림)
   user: 1000 * 60 * 1, // 1분 (단일 유저 ['users', uid])
-  users: 1000 * 60 * 1, // 1분 (전체 유저 ['users'])
+  users: 1000 * 60 * 3, // 3분 (전체 유저 ['users'])
   myProjects: 1000 * 60 * 1, // 1분 (공개프로필/마이페이지 프로젝트 ['myProjects'])
-  mostViewedPosts: 1000 * 60 * 3, // 3분 (인기 포스트 ['posts', 'mostViewed'])
-  mostLikedPosts: 1000 * 60 * 3, // 3분 (인기 포스트 ['posts', 'mostLiked'])
+  mostViewedPosts: 1000 * 60 * 5, // 5분 (인기 포스트 ['posts', 'mostViewed'])
+  mostLikedPosts: 1000 * 60 * 5, // 5분 (인기 포스트 ['posts', 'mostLiked'])
   filterPost: Infinity, // 무한 (필터링용 전체 포스트 ['post', 'projectIdList']) 포스트 삭제될 때만 invalidation
+  likedProjects: 1000 * 60 * 3, // 3분 (좋아요한 프로젝트 ['likedProjects']),
+  project: 1000 * 60 * 3, // 3분 (단일 프로젝트 ['projects', projectId])
 };


### PR DESCRIPTION
## 개요 🔎

React Query 에러를 해결하고, staleTime을 조정했습니다.

## 작업사항 📝

- 로그인하지 않은 상태에서 ContentCard 클릭 시 로그인 모달을 띄우는 로직 추가
- useQuery 옵션에 enabled 추가하여 params가 존재하지 않을 때 disabled 처리
- defaultOptions의 staleTime 제거 (모든 쿼리에 staleTime이 덮어씌워지고 있어서 삭제했습니다.)
- 전체 유저, 인기 포스트 staleTime을 늘렸습니다.

## 패키지 설치내용 📦

`적용했던 Package의 install 명령어를 남겨주세요.`