### PR TITLE
[fix] 모바일 프로젝트 상세보기 디자인 수정

### DIFF
--- a/src/components/projectDetail/mobile/MobileTitleThumbnailArea.tsx
+++ b/src/components/projectDetail/mobile/MobileTitleThumbnailArea.tsx
@@ -4,6 +4,7 @@ import { useAuth } from 'hooks';
 import { useState } from 'react';
 import { IoMdMore } from 'react-icons/io';
 import ModifyDeleteDropDown from './ModifyDeleteDropDown';
+import defaultThumbnail from 'assets/images/thumbnail_small.webp';
 
 const MobileTitleThumbnailArea = ({ pid, projectData }: any) => {
   const [popup, setPopup] = useState(false);
@@ -26,7 +27,7 @@ const MobileTitleThumbnailArea = ({ pid, projectData }: any) => {
         )}
       </TitleThumbnailAreaContainer>
       <ProjectThumbnail
-        src={projectData?.thumbnail}
+        src={projectData?.thumbnail || defaultThumbnail}
         alt={projectData?.title + ' 썸네일 이미지'}
       />
       <ModifyDeleteDropDown

--- a/src/components/projectDetail/mobile/MobileTitleThumbnailArea.tsx
+++ b/src/components/projectDetail/mobile/MobileTitleThumbnailArea.tsx
@@ -70,7 +70,7 @@ const IsRecruitingDiv = styled.div<{ children: string }>`
   align-items: center;
   padding: 0rem;
   gap: 0.625rem;
-  width: 3.75rem;
+  min-width: 3.75rem;
   height: 1.75rem;
   font-size: 0.875rem;
   background: ${({ children }) =>

--- a/src/components/projectDetail/mobile/MobileTitleThumbnailArea.tsx
+++ b/src/components/projectDetail/mobile/MobileTitleThumbnailArea.tsx
@@ -79,7 +79,13 @@ const IsRecruitingDiv = styled.div<{ children: string }>`
   color: ${COLORS.white};
 `;
 
-const TitleDiv = styled.div``;
+const TitleDiv = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;
 
 const ProjectThumbnail = styled.img`
   min-width: 12.5rem;


### PR DESCRIPTION
## 개요 🔎

모바일 프로젝트 상세보기 페이지 디자인을 수정했습니다.

## 작업사항 📝

<img width="326" alt="image" src="https://user-images.githubusercontent.com/88768022/222462490-51c50475-ca58-418f-9108-fa33e1df7eb1.png">

- 기본 썸네일 이미지 추가
- 제목 글자수가 두줄 이상 넘어가면 ellipsis 적용
- 모집중 최소너비 적용

## 패키지 설치내용 📦

.