### PR TITLE
[fix] Content Card 좋아요 클릭시 query invalidate 처리

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -57,6 +57,7 @@ const ContentCard = ({
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['likedProjects', uid]);
+        queryClient.invalidateQueries(['myProjects', uid]);
       },
     },
   );

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -54,6 +54,7 @@ const MobileContentCard = ({
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['likedProjects', uid]);
+        queryClient.invalidateQueries(['myProjects', uid]);
       },
     },
   );


### PR DESCRIPTION
## 개요 :mag_right:

Close #360 
Content Card에서 좋아요 버튼 클릭시 Mypage 관심 프로젝트에 새로고침 할 때만 반영되는 버그 처리

## 작업사항 :pencil:

- Content Card `useMuate`에 Mypage query key `Query invalidate`처리 

## 패키지 설치내용 :package: