### PR TITLE
[fix] 디테일 페이지에서 좋아요 클릭시 Content Card에 반영 안되는 현상 수정

### DIFF
--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -61,6 +61,7 @@ const Likes = ({ pid, version = 'web' }: any) => {
         queryClient.invalidateQueries(['myProjects', uid]);
         queryClient.invalidateQueries(['post', 'mostViewed']);
         queryClient.invalidateQueries(['post', 'mostLiked']);
+        queryClient.invalidateQueries(['likedProjects', uid]);
       },
     },
   );


### PR DESCRIPTION
## 개요 :mag_right:

close #360 
디테일 페이지 좋아요 버튼 클릭시 Content Card에 있는 하트 아이콘에 바로 적용 안되는 현상 수정

## 작업사항 :pencil:
- 디테일 페이지에서 좋아요 버튼 클릭시 팀원찾기 페이지에서 받아오는 데이터 invalid 처리

## 패키지 설치내용 :package: