### PR TITLE
[fix] 보낸 쪽지함에서 받는 사람 닉네임을 표시

### DIFF
--- a/src/components/popup/NoteMessage.tsx
+++ b/src/components/popup/NoteMessage.tsx
@@ -8,16 +8,16 @@ interface NoteMessageProps {
 }
 
 export default function NoteMessage({ type, data }: NoteMessageProps) {
-  const { handleTitleClick, sender } = useNoteMessage(type, data);
+  const { handleTitleClick, displayUser } = useNoteMessage(type, data);
 
-  if (!sender) return null;
+  if (!displayUser) return null;
   return (
     <MessageContainer>
       <MessageTitleDiv isRead={data.isRead} onClick={handleTitleClick}>
         {data.title}
       </MessageTitleDiv>
       <MessageDateDiv>
-        {sender.displayName} | {getDateAndTime(data.date)}
+        {displayUser.displayName} | {getDateAndTime(data.date)}
       </MessageDateDiv>
     </MessageContainer>
   );

--- a/src/hooks/useNoteMessage.ts
+++ b/src/hooks/useNoteMessage.ts
@@ -12,9 +12,9 @@ const useNoteMessage = (type: string, data: Note) => {
   const user = useAuth();
   const { openModalWithData } = useGlobalModal();
 
-  // sender의 프로필 정보
-  const { data: sender } = useQuery({
-    queryKey: ['users', data.senderUid],
+  // 받은 쪽지함은 보낸 사람 닉네임을 표시, 보낸 쪽지함은 받는 사람 닉네임을 표시
+  const { data: displayUser } = useQuery({
+    queryKey: ['users', type === 'inbox' ? data.senderUid : data.receiverUid],
     queryFn: getUserInfoData,
     staleTime: staleTime.user,
   });
@@ -46,7 +46,7 @@ const useNoteMessage = (type: string, data: Note) => {
     }
   };
 
-  return { handleTitleClick, sender };
+  return { handleTitleClick, displayUser };
 };
 
 export default useNoteMessage;


### PR DESCRIPTION
## 개요 🔎

Closes #364 
보낸 쪽지함에서 받는 사람 닉네임을 표시하도록 수정했습니다.

## 작업사항 📝
- `useNoteMessage` 커스텀훅에서 inbox일 경우 보낸 사람, outbox일 받는 사람의 사용자 정보를 가져오도록 변경



## 패키지 설치내용 📦

.