### PR TITLE
[feat] 팀원 찾기 페이지 카드 좋아요 클릭시 카운트 바로 반영 되도록 변경

### DIFF
--- a/src/apis/boardService.ts
+++ b/src/apis/boardService.ts
@@ -145,3 +145,15 @@ export const firebaseLikeProjectUpdateRequest = async (
     console.error(e);
   }
 };
+
+export const firebaseGetLikdCountRequest = async (id: string) => {
+  try {
+    const postRef = doc(firestore, 'post', id);
+    const snapshot = await getDoc(postRef);
+    if (snapshot.exists()) {
+      return snapshot.data().like;
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -15,12 +15,14 @@ import styled from '@emotion/styled';
 interface Props {
   project: EditType.EditFormType;
   likedProjects: string[];
+  onUpdateLikedCountEvent?: (id: string) => void;
   onNavigateToProjectDetailEvent: (path: string) => () => void;
 }
 
 const ContentCard = ({
   project,
   likedProjects,
+  onUpdateLikedCountEvent,
   onNavigateToProjectDetailEvent,
 }: Props) => {
   const {
@@ -58,6 +60,7 @@ const ContentCard = ({
       onSuccess: () => {
         queryClient.invalidateQueries(['likedProjects', uid]);
         queryClient.invalidateQueries(['myProjects', uid]);
+        onUpdateLikedCountEvent?.(id);
       },
     },
   );

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -11,17 +11,19 @@ import defaultThumbnail from 'assets/images/thumbnail_mobile.png';
 import COLORS from 'assets/styles/colors';
 import styled from '@emotion/styled';
 interface Props {
+  pid?: string;
   project: EditType.EditFormType;
   likedProjects: string[];
-  pid?: string;
+  onUpdateLikedCountEvent?: (id: string) => void;
   onNavigateToProjectDetailEvent: (path: string) => () => void;
 }
 
 const MobileContentCard = ({
+  pid,
   project,
   likedProjects,
+  onUpdateLikedCountEvent,
   onNavigateToProjectDetailEvent,
-  pid,
 }: Props) => {
   const {
     id,
@@ -55,6 +57,7 @@ const MobileContentCard = ({
       onSuccess: () => {
         queryClient.invalidateQueries(['likedProjects', uid]);
         queryClient.invalidateQueries(['myProjects', uid]);
+        onUpdateLikedCountEvent?.(id);
       },
     },
   );

--- a/src/components/findproject/FindProjectList.tsx
+++ b/src/components/findproject/FindProjectList.tsx
@@ -7,6 +7,7 @@ interface Props {
   toggle: boolean;
   category: string;
   likedProjects: string[];
+  onUpdateLikedCountEvent: (id: string) => void;
   onNavigateToProjectDetailEvent: (path: string) => () => void;
 }
 
@@ -15,6 +16,7 @@ const FindProjectList = ({
   toggle,
   category,
   likedProjects,
+  onUpdateLikedCountEvent,
   onNavigateToProjectDetailEvent,
 }: Props) => {
   return (
@@ -28,6 +30,7 @@ const FindProjectList = ({
                 key={project.id}
                 project={project}
                 likedProjects={likedProjects}
+                onUpdateLikedCountEvent={onUpdateLikedCountEvent}
                 onNavigateToProjectDetailEvent={onNavigateToProjectDetailEvent}
               />
             )
@@ -36,6 +39,7 @@ const FindProjectList = ({
               key={project.id}
               project={project}
               likedProjects={likedProjects}
+              onUpdateLikedCountEvent={onUpdateLikedCountEvent}
               onNavigateToProjectDetailEvent={onNavigateToProjectDetailEvent}
             />
           ),

--- a/src/components/findproject/mobile/FindProjectMobileList.tsx
+++ b/src/components/findproject/mobile/FindProjectMobileList.tsx
@@ -7,6 +7,7 @@ interface Props {
   toggle: boolean;
   category: string;
   likedProjects: string[];
+  onUpdateLikedCountEvent: (id: string) => void;
   onNavigateToProjectDetailEvent: (path: string) => () => void;
 }
 
@@ -15,6 +16,7 @@ const FindProjectMobileList = ({
   toggle,
   category,
   likedProjects,
+  onUpdateLikedCountEvent,
   onNavigateToProjectDetailEvent,
 }: Props) => {
   return (
@@ -28,6 +30,7 @@ const FindProjectMobileList = ({
                 key={project.id}
                 project={project}
                 likedProjects={likedProjects}
+                onUpdateLikedCountEvent={onUpdateLikedCountEvent}
                 onNavigateToProjectDetailEvent={onNavigateToProjectDetailEvent}
               />
             )
@@ -36,6 +39,7 @@ const FindProjectMobileList = ({
               key={project.id}
               project={project}
               likedProjects={likedProjects}
+              onUpdateLikedCountEvent={onUpdateLikedCountEvent}
               onNavigateToProjectDetailEvent={onNavigateToProjectDetailEvent}
             />
           ),

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -2,7 +2,10 @@ import { useEffect, useState, useCallback, MouseEvent } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from 'hooks';
-import { firebaseInfinityScrollProjectDataRequest } from 'apis/boardService';
+import {
+  firebaseGetLikdCountRequest,
+  firebaseInfinityScrollProjectDataRequest,
+} from 'apis/boardService';
 import { firebaseFindMyInterestRequest } from 'apis/userService';
 import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 import { EditType } from 'types/write/writeType';
@@ -85,6 +88,15 @@ const useFindProject = () => {
     navigate(`/project/${path}`);
   };
 
+  const handleUpdateLikedCount = useCallback(async (id: string) => {
+    const likeCount = await firebaseGetLikdCountRequest(id);
+    setProjects((prev) =>
+      prev.map((project) =>
+        project.id === id ? { ...project, like: likeCount } : project,
+      ),
+    );
+  }, []);
+
   return {
     toggle,
     projects,
@@ -92,6 +104,7 @@ const useFindProject = () => {
     likedProjects,
     handleToggleClick,
     handleCategoryClick,
+    handleUpdateLikedCount,
     handleNavigateToProjectDetail,
   };
 };

--- a/src/pages/FindProjectPage.tsx
+++ b/src/pages/FindProjectPage.tsx
@@ -15,6 +15,7 @@ const FindProjectPage = () => {
     likedProjects,
     handleToggleClick,
     handleCategoryClick,
+    handleUpdateLikedCount,
     handleNavigateToProjectDetail,
   } = useFindProject();
   const isMobile = useIsMobile();
@@ -37,6 +38,7 @@ const FindProjectPage = () => {
             category={category}
             projects={projects}
             likedProjects={likedProjects}
+            onUpdateLikedCountEvent={handleUpdateLikedCount}
             onNavigateToProjectDetailEvent={handleNavigateToProjectDetail}
           />
         </FindProjectMobilePageContainer>
@@ -62,6 +64,7 @@ const FindProjectPage = () => {
             category={category}
             projects={projects}
             likedProjects={likedProjects}
+            onUpdateLikedCountEvent={handleUpdateLikedCount}
             onNavigateToProjectDetailEvent={handleNavigateToProjectDetail}
           />
         </WebContainer>


### PR DESCRIPTION
## 개요 :mag_right:

close #369 
카드에서 좋아요 클릭시 카운트 바로 반영 되도록 수정

## 작업사항 :pencil:

- firebase 좋아요 카운트 가져오는 로직 생성
- PC & Mobile Content Card에 좋아요 기능 클릭시 카운트 되도록 로직 수정

## 패키지 설치내용 :package: