### PR TITLE
[fix] 인풋태그 클리어 버튼 버그, placeholder 수정

### DIFF
--- a/src/components/mypage/TextInput.tsx
+++ b/src/components/mypage/TextInput.tsx
@@ -31,7 +31,7 @@ const TextInput = ({
         <InfoTextInput
           type="text"
           name={name}
-          defaultValue={value}
+          value={value}
           onChange={onChangeValue}
           placeholder={placeholder}
           minLength={2}
@@ -43,7 +43,7 @@ const TextInput = ({
         <InfoTextInput
           type="email"
           name={name}
-          defaultValue={value}
+          value={value}
           onChange={onChangeValue}
           placeholder={placeholder}
           minLength={2}

--- a/src/components/mypage/mobile/MobileTopTab.tsx
+++ b/src/components/mypage/mobile/MobileTopTab.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import { LeftTabProps } from '../LeftTab';
 
-const TobTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
+const MobileTopTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
   // 탭 활성화하는 함수
   const handleTabClick = (e: React.MouseEvent<HTMLLIElement>) => {
     const { innerText } = e.currentTarget;
@@ -27,7 +27,7 @@ const TobTab = ({ activeTab, setActiveTab }: LeftTabProps) => {
   );
 };
 
-export default TobTab;
+export default MobileTopTab;
 
 const TabContainer = styled.div`
   width: 100%;

--- a/src/components/mypage/mobile/MobileUserInfo.tsx
+++ b/src/components/mypage/mobile/MobileUserInfo.tsx
@@ -113,7 +113,7 @@ const MobileUserInfo = ({ user }: MypageInfoProps) => {
           value={userInfo.email ?? ''}
           onChangeValue={handleInputChange}
           onClearValue={handleInputClear}
-          placeholder="연락처로 쓰일 이메일을 입력해주세요."
+          placeholder="이메일을 입력해주세요."
           validationMessage={contactValidationMessage}
           isEmail={true}
           isMobile={isMobile}

--- a/src/hooks/useUpdateProfile.ts
+++ b/src/hooks/useUpdateProfile.ts
@@ -57,20 +57,23 @@ const useUpdateProfile = () => {
         return { ...prevState, [name]: value };
       });
     },
-    [],
+    [userInfo],
   );
 
   // 텍스트 인풋 클리어
-  const handleInputClear = useCallback((e: React.MouseEvent<SVGAElement>) => {
-    const { name, value } = e.currentTarget
-      .previousElementSibling as HTMLInputElement;
+  const handleInputClear = useCallback(
+    (e: React.MouseEvent<SVGAElement>) => {
+      const { name, value } = e.currentTarget
+        .previousElementSibling as HTMLInputElement;
 
-    if (value === '') return;
+      if (value === '') return;
 
-    setUserInfo((prevState) => {
-      return { ...prevState, [name]: '' };
-    });
-  }, []);
+      setUserInfo((prevState) => {
+        return { ...prevState, [name]: '' };
+      });
+    },
+    [userInfo],
+  );
 
   // 정보완료 버튼 유효성 검사
   const checkInfoValidation = () => {
@@ -92,18 +95,21 @@ const useUpdateProfile = () => {
     return true;
   };
 
-  const updateDefaultUserInfoState = useCallback((user: UserInfo) => {
-    setDefaultUserInfo({
-      displayName: user?.displayName,
-      email: user?.email,
-      photoURL: user?.photoURL,
-      isJunior: user?.isJunior,
-      positions: user?.positions,
-      plannerStack: user?.plannerStack || [''],
-      designerStack: user?.designerStack || [''],
-      developerStack: user?.developerStack || [''],
-    });
-  }, []);
+  const updateDefaultUserInfoState = useCallback(
+    (user: UserInfo) => {
+      setDefaultUserInfo({
+        displayName: user?.displayName,
+        email: user?.email,
+        photoURL: user?.photoURL,
+        isJunior: user?.isJunior,
+        positions: user?.positions,
+        plannerStack: user?.plannerStack || [''],
+        designerStack: user?.designerStack || [''],
+        developerStack: user?.developerStack || [''],
+      });
+    },
+    [defaultInfo],
+  );
 
   return {
     validationMessage,


### PR DESCRIPTION
## 개요 🔎

Fixes #368 

마이페이지, 회원가입에서 사용되는 인풋 태그 클리어 버튼 버그,
모바일 마이페이지 정보수정 이메일 부분의 placeholder가 클리어 버튼과 겹치는 현상 수정을 했습니다.

## 작업사항 📝

* TextInput 컴포넌트의 input 태그 `defaultValue` 속성을 `value`로 수정
* 모바일 마이페이지 정보수정 이메일 placeholder 수정
* 모바일 탭 컴포넌트명 오타 수정

## 패키지 설치내용 📦

.