### PR TITLE
[fix] 에디터 툴바 렌더링이 안되는 에러 수정

### DIFF
--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -14,17 +14,17 @@ interface Props {
   value?: string;
 }
 
-const TextEditor = ({ editRef, value }: Props) => {
-  const toolbarItems: Array<Array<string>> = [
-    ['heading', 'bold', 'italic', 'strike'],
-    ['hr'],
-    ['ul', 'ol', 'task'],
-    ['table', 'link'],
-    ['image'],
-    ['code'],
-    ['scrollSync'],
-  ];
+const toolbarItems: Array<Array<string>> = [
+  ['heading', 'bold', 'italic', 'strike'],
+  ['hr'],
+  ['ul', 'ol', 'task'],
+  ['table', 'link'],
+  ['image'],
+  ['code'],
+  ['scrollSync'],
+];
 
+const TextEditor = ({ editRef, value }: Props) => {
   return (
     <Editor
       ref={editRef}


### PR DESCRIPTION
## 개요 🔎

베타 테스터 피드백 중 Toast UI Editor 툴바 아이템이 렌더링 되지 않는 에러를 수정했습니다.

## 작업사항 📝

- toolbarItems 배열을 컴포넌트 외부로 위치 이동

## 패키지 설치내용 📦

.