### PR TITLE
[feat] 프로젝트 상세보기, 공개프로필 페이지의 query에  suspense 적용

### DIFF
--- a/src/components/main/banner/MainBanner.tsx
+++ b/src/components/main/banner/MainBanner.tsx
@@ -49,7 +49,6 @@ const MainBanner = () => {
             src={require('assets/videos/logo_main2.webm')}
             loop
             autoPlay
-            muted
             controls={false}
           />
         </BannerContainer>

--- a/src/hooks/usePublicProfile.ts
+++ b/src/hooks/usePublicProfile.ts
@@ -1,5 +1,5 @@
 import { logEvent } from '@amplitude/analytics-browser';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { getUserInfoData, getUserProjectList } from 'apis/mypageUsers';
 import { modalTypes } from 'components/common/modal/modal';
 import { useEffect } from 'react';
@@ -24,17 +24,25 @@ const usePubicProfile = () => {
   const { openModalWithData, openModal } = useGlobalModal();
   const isMobile = useIsMobile();
 
-  const { data: userInfoData } = useQuery({
-    queryKey: ['users', pid],
-    queryFn: getUserInfoData,
-    staleTime: staleTime.user,
-  });
-
-  const { data: userProjectListsData } = useQuery({
-    queryKey: ['myProjects', pid],
-    queryFn: getUserProjectList,
-    staleTime: staleTime.myProjects,
-    enabled: !!pid,
+  const [{ data: userInfoData }, { data: userProjectListsData }] = useQueries({
+    queries: [
+      //유저 정보 조회
+      {
+        queryKey: ['users', pid],
+        queryFn: getUserInfoData,
+        staleTime: staleTime.user,
+        enabled: !!pid,
+        suspense: true,
+      },
+      //유저가 참여한 프로젝트 조회
+      {
+        queryKey: ['myProjects', pid],
+        queryFn: getUserProjectList,
+        staleTime: staleTime.myProjects,
+        enabled: !!pid,
+        suspense: true,
+      },
+    ],
   });
 
   const handleSendNoteButtonClick = () => {


### PR DESCRIPTION
## 개요 🔎

기존: useQuery를 이용하는 페이지에 접근 시 두번째부터는 캐싱 데이터로 인해 로딩 페이지가 나타나지 않음
변경: useQuery 옵션에 suspense를 적용하여 fetching 시에도 로딩 페이지가 나타나도록 변경함

## 작업사항 📝

- useDetailProject, usePublicProfile 훅의 query 옵션에 suspense를 추가

## 패키지 설치내용 📦

.