### PR TITLE
[fix] 유효성 검사 전 텍스트 trim

### DIFF
--- a/src/hooks/useEditBoard.ts
+++ b/src/hooks/useEditBoard.ts
@@ -63,7 +63,7 @@ const useEditBoard = () => {
     const markdownText = editRef.current.getInstance().getMarkdown();
     const validations = [
       {
-        isValid: titleValidation(title),
+        isValid: titleValidation(title.trim()),
         message: '타이틀 길이는 5자 이상 40자 이하로 작성해주세요.',
       },
       {
@@ -88,7 +88,7 @@ const useEditBoard = () => {
         message: '마감 날짜는 오늘 이후로 설정해주세요.',
       },
       {
-        isValid: contentValidation(markdownText),
+        isValid: contentValidation(markdownText.trim()),
         message: '내용 길이는 10자 이상 적어주세요.',
       },
     ];

--- a/src/hooks/useNote.ts
+++ b/src/hooks/useNote.ts
@@ -38,18 +38,26 @@ const useNote = () => {
 
   // 쪽지 유효성 검사
   const checkNoteValidation = (note: any) => {
-    if (!note.title || !note.content) {
+    const trimmedNote = {
+      title: note.title.trim(),
+      content: note.content.trim(),
+    };
+
+    if (!trimmedNote.title || !trimmedNote.content) {
       handleToastPopup('제목은 2자 이상, 내용은 5자 이상 입력해주세요.');
       return false;
     }
-    if (note.title.length < 2 || note.content.length < 5) {
+
+    if (trimmedNote.title.length < 2 || trimmedNote.content.length < 5) {
       handleToastPopup('제목은 2자 이상, 내용은 5자 이상 입력해주세요.');
       return false;
     }
-    if (note.title.length > 30 || note.content.length > 500) {
+
+    if (trimmedNote.title.length > 30 || trimmedNote.content.length > 500) {
       handleToastPopup('제목은 30자 이하, 내용은 500자 이하 입력해주세요.');
       return false;
     }
+
     return true;
   };
 

--- a/src/hooks/useUpdateProfile.ts
+++ b/src/hooks/useUpdateProfile.ts
@@ -35,16 +35,16 @@ const useUpdateProfile = () => {
 
       const isValidate =
         name === 'displayName'
-          ? nicknameValidation(value)
-          : contactValidation(value);
+          ? nicknameValidation(value.trim())
+          : contactValidation(value.trim());
 
       if (!isValidate) {
         if (name === 'displayName') {
-          value.length < 2
+          value.trim().length < 2
             ? setValidationMessage('닉네임은 2자 이상이어야 합니다.')
             : setValidationMessage('닉네임은 7자 이하여야 합니다.');
         } else {
-          value === ''
+          value.trim() === ''
             ? setContactValidationMessage('이메일을 입력해주세요.')
             : setContactValidationMessage('이메일을 올바르게 입력해주세요.');
         }

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -43,7 +43,7 @@ const useWrite = () => {
     const markdownText = editRef.current.getInstance().getMarkdown();
     const invalidValidation = [
       {
-        isValid: titleValidation(title),
+        isValid: titleValidation(title.trim()),
         message: '타이틀 길이는 5자 이상 40자 이하로 작성해주세요.',
       },
       {
@@ -68,7 +68,7 @@ const useWrite = () => {
         message: '마감 날짜는 오늘 이후로 설정해주세요.',
       },
       {
-        isValid: contentValidation(markdownText),
+        isValid: contentValidation(markdownText.trim()),
         message: '내용 길이는 10자 이상 적어주세요.',
       },
     ].find(({ isValid }) => !isValid);


### PR DESCRIPTION
## 개요 🔎

공백 문자열을 입력할 때 유효성 검사가 통과되는 버그가 있어
텍스트를 trim 후 유효성 검사를 진행하도록 수정했습니다.

## 작업사항 📝

- 프로젝트 글 작성/수정 - 제목, 내용
- 쪽지 - 제목, 내용
- 회원가입 - 닉네임, 연락처

## 패키지 설치내용 📦

.