### PR TITLE
[PR] 프로필 변경 시 프로젝트 상세보기 페이지, 초대하기 모달, 공개프로필에 반영

### DIFF
--- a/src/apis/boardService.ts
+++ b/src/apis/boardService.ts
@@ -148,7 +148,7 @@ export const firebaseLikeProjectUpdateRequest = async (
   }
 };
 
-export const firebaseGetLikdCountRequest = async (id: string) => {
+export const firebaseGetLikedCountRequest = async (id: string) => {
   try {
     const postRef = doc(firestore, 'post', id);
     const snapshot = await getDoc(postRef);

--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -60,8 +60,6 @@ export const updateAppliedProject = async (
 export const updateApplicants = async (
   pid: string,
   uid: string,
-  displayName: string,
-  profileURL: string,
   skills: any,
   position: string,
   motive: string,
@@ -73,9 +71,6 @@ export const updateApplicants = async (
     {
       applicants: {
         [uid]: {
-          uid: uid,
-          displayName: displayName,
-          profileURL: profileURL,
           skills: skills,
           position: position,
           motive: motive,

--- a/src/components/common/myProjectList/ProjectItemMembers.tsx
+++ b/src/components/common/myProjectList/ProjectItemMembers.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
+import ParticipantsProfile from 'components/projectDetail/ParticipantsProfile';
 
 const ProjectItemMembers = ({ applicants, positions }: any) => {
   if (applicants === undefined) applicants = {};
@@ -17,15 +18,7 @@ const ProjectItemMembers = ({ applicants, positions }: any) => {
           <ProjectMemberList>
             {members?.map((key: any) => {
               if (applicants[key].position === '기획')
-                return (
-                  <ProjectMemberItem key={key}>
-                    <ProjectMemberProfileImg
-                      src={applicants[key].profileURL}
-                      alt="멤버프로필이미지"
-                      referrerPolicy="no-referrer"
-                    />
-                  </ProjectMemberItem>
-                );
+                return <ParticipantsProfile key={key} participantsUid={key} />;
             })}
           </ProjectMemberList>
         </ProjectMemberPositionList>
@@ -36,15 +29,7 @@ const ProjectItemMembers = ({ applicants, positions }: any) => {
           <ProjectMemberList>
             {members.map((key) => {
               if (applicants[key].position === '디자인')
-                return (
-                  <ProjectMemberItem key={key}>
-                    <ProjectMemberProfileImg
-                      src={applicants[key].profileURL}
-                      alt="멤버프로필이미지"
-                      referrerPolicy="no-referrer"
-                    />
-                  </ProjectMemberItem>
-                );
+                return <ParticipantsProfile key={key} participantsUid={key} />;
             })}
           </ProjectMemberList>
         </ProjectMemberPositionList>
@@ -55,15 +40,7 @@ const ProjectItemMembers = ({ applicants, positions }: any) => {
           <ProjectMemberList>
             {members.map((key) => {
               if (applicants[key].position === '프론트엔드')
-                return (
-                  <ProjectMemberItem key={key}>
-                    <ProjectMemberProfileImg
-                      src={applicants[key].profileURL}
-                      alt="멤버프로필이미지"
-                      referrerPolicy="no-referrer"
-                    />
-                  </ProjectMemberItem>
-                );
+                return <ParticipantsProfile key={key} participantsUid={key} />;
             })}
           </ProjectMemberList>
         </ProjectMemberPositionList>
@@ -74,15 +51,7 @@ const ProjectItemMembers = ({ applicants, positions }: any) => {
           <ProjectMemberList>
             {members.map((key) => {
               if (applicants[key].position === '백엔드')
-                return (
-                  <ProjectMemberItem key={key}>
-                    <ProjectMemberProfileImg
-                      src={applicants[key].profileURL}
-                      alt="멤버프로필이미지"
-                      referrerPolicy="no-referrer"
-                    />
-                  </ProjectMemberItem>
-                );
+                return <ParticipantsProfile key={key} participantsUid={key} />;
             })}
           </ProjectMemberList>
         </ProjectMemberPositionList>
@@ -92,13 +61,6 @@ const ProjectItemMembers = ({ applicants, positions }: any) => {
 };
 
 export default ProjectItemMembers;
-
-const ProjectMemberProfileImg = styled.img`
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
 
 const ProjectInfoLabel = styled.strong`
   display: block;
@@ -135,12 +97,4 @@ const ProjectMemberList = styled.ul`
   align-items: center;
   min-height: 3.25rem;
   gap: 1.5rem;
-`;
-
-const ProjectMemberItem = styled.li`
-  width: 2.6rem;
-  height: 2.6rem;
-  border-radius: 50%;
-  overflow: hidden;
-  margin-top: 0.3rem;
 `;

--- a/src/components/editpage/EditPageDeadline.tsx
+++ b/src/components/editpage/EditPageDeadline.tsx
@@ -26,7 +26,7 @@ const EditPageDeadline = ({
             onChange={onFormValueChangeEvent}
           />
           <BodyDeadlineText>
-            입력하신 날짜 11시 59분에 자동 마감됩니다.
+            입력하신 날짜 자정에 자동 마감됩니다.
           </BodyDeadlineText>
         </BodyDeadlineBox>
       )}

--- a/src/components/login/SetProfile.tsx
+++ b/src/components/login/SetProfile.tsx
@@ -27,8 +27,7 @@ export default function SetProfile() {
   const { showToast, ToastMessage, handleToastPopup } = useToastPopup();
   const { openModal } = useGlobalModal();
 
-  const user = useAuth();
-  const { uid } = user;
+  const { uid } = useAuth();
 
   const { data: userInfoData }: any = useQuery({
     queryKey: ['users', uid],
@@ -47,8 +46,8 @@ export default function SetProfile() {
 
   // 닉네임  유효성 검사
   const checkValidation = () => {
-    const nameLenght = userInfo.displayName.length;
-    if (nameLenght < 2 || nameLenght > 7) {
+    const nameLength = userInfo.displayName.length;
+    if (nameLength < 2 || nameLength > 7) {
       handleToastPopup('닉네임은 2자 이상 7자 이하로 입력해주세요.');
       return false;
     }

--- a/src/components/projectDetail/ApplicantCard.tsx
+++ b/src/components/projectDetail/ApplicantCard.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getUserInfoData } from 'apis/mypageUsers';
 import COLORS from 'assets/styles/colors';
 import { useNavigate } from 'react-router-dom';
+import { staleTime } from 'utils/staleTime';
 
 const ApplicantCard = ({
   applicant,
@@ -11,21 +14,28 @@ const ApplicantCard = ({
 }: any) => {
   const navigate = useNavigate();
 
+  // 유저 정보 받아오는 쿼리
+  const { data: applierInfoData }: any = useQuery({
+    queryKey: ['users', applicantUid],
+    queryFn: getUserInfoData,
+    staleTime: staleTime.users,
+  });
+
   return (
     <>
-      <ApplicantWrap key={applicant?.uid} isOpen={isOpen}>
+      <ApplicantWrap key={applicantUid} isOpen={isOpen}>
         <ProfileImageDiv>
           <ProfileImage
-            src={applicant?.profileURL}
-            alt={applicant?.displayName}
+            src={applierInfoData?.photoURL}
+            alt={applierInfoData?.displayName}
             referrerPolicy="no-referrer"
-            onClick={() => navigate(`/profile/${applicant.uid}`)}
+            onClick={() => navigate(`/profile/${applicantUid}`)}
           />
 
           <HoverText>클릭 시 공개 프로필로 이동</HoverText>
         </ProfileImageDiv>
 
-        <NicknameDiv>{applicant?.displayName}</NicknameDiv>
+        <NicknameDiv>{applierInfoData?.displayName}</NicknameDiv>
         <PositionDiv>{applicant?.position}</PositionDiv>
         <StackContainer>
           <StackWrap>

--- a/src/components/projectDetail/ApplicantListArea.tsx
+++ b/src/components/projectDetail/ApplicantListArea.tsx
@@ -40,14 +40,14 @@ const ApplicantListArea = ({ projectData, pid }: any) => {
           <StyledSlider {...settings} infinite={applicants.length >= 4}>
             {applicants &&
               Object.keys(applicants).map((key) => {
-                if (applicants[key]?.recruit === false) {
+                if (applicants?.[key]?.recruit === false) {
                   countFlag += 1;
                   return (
                     <ApplicantCard
                       key={key}
                       pid={pid}
                       applicantUid={key}
-                      applicant={applicants[key]}
+                      applicant={applicants?.[key]}
                       setClickApplicant={setClickApplicant}
                       handleModalStateChange={handleModalStateChange}
                       isOpen={isOpen}
@@ -66,7 +66,7 @@ const ApplicantListArea = ({ projectData, pid }: any) => {
         applicant={applicants?.[clickApplicant]}
         onClickEvent={handleModalStateChange}
         pid={pid}
-        applicantKey={applicants?.[clickApplicant]?.uid}
+        applicantKey={clickApplicant}
       />
     </>
   );

--- a/src/components/projectDetail/InviteModals/InviteModal.tsx
+++ b/src/components/projectDetail/InviteModals/InviteModal.tsx
@@ -8,7 +8,7 @@ import {
   useModal,
   useNotification,
 } from 'hooks';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { updateAppliedProject, updateParticipants } from 'apis/postDetail';
 import { modalTypes } from 'components/common/modal/modal';
 import MobileInviteModal from '../mobile/MobileModal/MobileInviteModal';
@@ -16,6 +16,8 @@ import {
   amplitudeNeedToButtonClick,
   amplitudeToNoneButtonClick,
 } from 'utils/amplitude';
+import { getUserInfoData } from 'apis/mypageUsers';
+import { staleTime } from 'utils/staleTime';
 
 interface props {
   isOpen: boolean;
@@ -37,6 +39,13 @@ const InviteModal = ({
   const { isOpen: isAlertOpen, handleModalStateChange: onAlertClickEvent } =
     useModal(false);
   const { sendNotification } = useNotification();
+
+  // 유저 정보 받아오는 쿼리
+  const { data: applierInfoData }: any = useQuery({
+    queryKey: ['users', applicantKey],
+    queryFn: getUserInfoData,
+    staleTime: staleTime.users,
+  });
 
   const { mutate: applicantMutate } = useMutation(() =>
     updateParticipants(
@@ -119,8 +128,8 @@ const InviteModal = ({
         <ModalWrapper>
           <ProfileToMessageContainer>
             <UserProfileImage
-              src={applicant?.profileURL}
-              alt={applicant?.displayName}
+              src={applierInfoData?.photoURL}
+              alt={applierInfoData?.displayName}
               referrerPolicy="no-referrer"
             />
             <MessageSendButton
@@ -146,7 +155,7 @@ const InviteModal = ({
             )}
           </UserSkillsContainer>
 
-          <InviteTitle>{applicant?.displayName} 님을</InviteTitle>
+          <InviteTitle>{applierInfoData?.displayName} 님을</InviteTitle>
           <InviteTitle>팀원으로 초대할까요?</InviteTitle>
 
           <MotiveContainer>

--- a/src/components/projectDetail/MemberInfoArea.tsx
+++ b/src/components/projectDetail/MemberInfoArea.tsx
@@ -1,7 +1,8 @@
-import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 import { logEvent } from 'utils/amplitude';
+import { useNavigate } from 'react-router-dom';
+import ParticipantsProfile from './ParticipantsProfile';
 
 const MemberInfoArea = ({ applicantsData }: any) => {
   const navigate = useNavigate();
@@ -44,12 +45,10 @@ const MemberInfoArea = ({ applicantsData }: any) => {
                 {participantsData?.map((key) => {
                   if (applicantsData[key].position === '기획')
                     return (
-                      <MemberProfileImg
+                      <ParticipantsProfile
                         key={key}
-                        onClick={() => onClickEvent(applicantsData[key].uid)}
-                        src={applicantsData[key].profileURL}
-                        alt={applicantsData[key].displayName}
-                        referrerPolicy="no-referrer"
+                        LinkToPublicProfile={onClickEvent}
+                        participantsUid={applicantsData[key].uid}
                       />
                     );
                 })}
@@ -61,12 +60,10 @@ const MemberInfoArea = ({ applicantsData }: any) => {
                 {participantsData.map((key) => {
                   if (applicantsData[key].position === '디자인')
                     return (
-                      <MemberProfileImg
+                      <ParticipantsProfile
                         key={key}
-                        onClick={() => onClickEvent(applicantsData[key].uid)}
-                        src={applicantsData[key].profileURL}
-                        alt={applicantsData[key].displayName}
-                        referrerPolicy="no-referrer"
+                        LinkToPublicProfile={onClickEvent}
+                        participantsUid={applicantsData[key].uid}
                       />
                     );
                 })}
@@ -79,12 +76,10 @@ const MemberInfoArea = ({ applicantsData }: any) => {
                 {participantsData.map((key) => {
                   if (applicantsData[key].position === '프론트엔드')
                     return (
-                      <MemberProfileImg
+                      <ParticipantsProfile
                         key={key}
-                        onClick={() => onClickEvent(applicantsData[key].uid)}
-                        src={applicantsData[key].profileURL}
-                        alt={applicantsData[key].displayName}
-                        referrerPolicy="no-referrer"
+                        LinkToPublicProfile={onClickEvent}
+                        participantsUid={applicantsData[key].uid}
                       />
                     );
                 })}
@@ -97,12 +92,10 @@ const MemberInfoArea = ({ applicantsData }: any) => {
                 {participantsData.map((key) => {
                   if (applicantsData[key].position === '백엔드')
                     return (
-                      <MemberProfileImg
+                      <ParticipantsProfile
                         key={key}
-                        onClick={() => onClickEvent(applicantsData[key].uid)}
-                        alt={applicantsData[key].displayName}
-                        src={applicantsData[key].profileURL}
-                        referrerPolicy="no-referrer"
+                        LinkToPublicProfile={onClickEvent}
+                        participantsUid={applicantsData[key].uid}
                       />
                     );
                 })}
@@ -160,60 +153,8 @@ const PositionDiv = styled.div`
 
   width: 4.125rem;
   height: 2.0625rem;
-
-  /* violet B 400 */
-
-  background: #6f64f2;
+  background: ${COLORS.violetB400};
   border-radius: 0.625rem;
-`;
-
-const MemberProfileImg = styled.img`
-  width: 3.25rem;
-  height: 3.25rem;
-  border-radius: 50%;
-  /* position: relative; */
-  object-fit: cover;
-  cursor: pointer;
-  z-index: 0;
-`;
-
-const HoverText = styled.div`
-  position: absolute;
-  top: 70%;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  z-index: 10;
-  width: 100%;
-  height: ${(props: { children: string }) =>
-    props.children.length > 5 ? '100%' : '1.875rem'};
-  border-radius: 0.625rem;
-  background-color: ${COLORS.white};
-  box-shadow: 0.0313rem 0.0313rem 0.625rem 0.1rem ${COLORS.violetB300};
-  color: ${COLORS.black};
-  z-index: 999;
-  align-items: center;
-  justify-content: center;
-  font-size: 1rem;
-  font-weight: 500;
-
-  display: none;
-`;
-
-const Div = styled.div`
-  position: relative;
-  width: 5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  cursor: pointer;
-  z-index: 0;
-  :hover > div {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 `;
 
 const NodataMessage = styled.p`

--- a/src/components/projectDetail/ParticipantsProfile.tsx
+++ b/src/components/projectDetail/ParticipantsProfile.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfoData } from 'apis/mypageUsers';
+import { staleTime } from 'utils/staleTime';
+
+const ParticipantsProfile = ({
+  LinkToPublicProfile,
+  participantsUid,
+  version = 'web',
+}: any) => {
+  // 유저 정보 받아오는 쿼리
+  const { data: applierInfoData }: any = useQuery({
+    queryKey: ['users', participantsUid],
+    queryFn: getUserInfoData,
+    staleTime: staleTime.users,
+  });
+
+  return (
+    <ProjectMemberItem version={version}>
+      <MemberProfileImg
+        onClick={() => LinkToPublicProfile(participantsUid)}
+        src={applierInfoData?.photoURL}
+        alt={applierInfoData?.displayName}
+        referrerPolicy="no-referrer"
+      />
+    </ProjectMemberItem>
+  );
+};
+export default ParticipantsProfile;
+
+const MemberProfileImg = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  cursor: pointer;
+  z-index: 0;
+`;
+const ProjectMemberItem = styled.li<{ version: string }>`
+  width: ${({ version }) => (version === 'mobile' ? '2rem' : '2.6rem')};
+  height: ${({ version }) => (version === 'mobile' ? '2rem' : '2.6rem')};
+  border-radius: 50%;
+  overflow: hidden;
+  margin-top: 0.3rem;
+  list-style-type: none;
+`;

--- a/src/components/projectDetail/ParticipantsProfile.tsx
+++ b/src/components/projectDetail/ParticipantsProfile.tsx
@@ -3,13 +3,19 @@ import { useQuery } from '@tanstack/react-query';
 import { getUserInfoData } from 'apis/mypageUsers';
 import { staleTime } from 'utils/staleTime';
 
+interface Props {
+  LinkToPublicProfile?: (uid: string) => void;
+  participantsUid: string;
+  version?: 'web' | 'mobile';
+}
+
 const ParticipantsProfile = ({
   LinkToPublicProfile,
   participantsUid,
   version = 'web',
-}: any) => {
+}: Props) => {
   // 유저 정보 받아오는 쿼리
-  const { data: applierInfoData }: any = useQuery({
+  const { data: applierInfoData } = useQuery({
     queryKey: ['users', participantsUid],
     queryFn: getUserInfoData,
     staleTime: staleTime.users,
@@ -18,7 +24,9 @@ const ParticipantsProfile = ({
   return (
     <ProjectMemberItem version={version}>
       <MemberProfileImg
-        onClick={() => LinkToPublicProfile(participantsUid)}
+        onClick={() =>
+          LinkToPublicProfile ? LinkToPublicProfile(participantsUid) : null
+        }
         src={applierInfoData?.photoURL}
         alt={applierInfoData?.displayName}
         referrerPolicy="no-referrer"

--- a/src/components/projectDetail/mobile/MobileApplicantCard.tsx
+++ b/src/components/projectDetail/mobile/MobileApplicantCard.tsx
@@ -5,22 +5,33 @@ import InviteModal from '../InviteModals/InviteModal';
 import { useModal } from 'hooks';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfoData } from 'apis/mypageUsers';
+import { staleTime } from 'utils/staleTime';
 
 const MobileApplicantCard = ({ pid, applicant, applicantUid }: any) => {
   const navigate = useNavigate();
   const { isOpen, handleModalStateChange } = useModal(false);
   const [applicantKey, setApplicantKey] = useState('');
+
+  // 유저 정보 받아오는 쿼리
+  const { data: applierInfoData }: any = useQuery({
+    queryKey: ['users', applicantUid],
+    queryFn: getUserInfoData,
+    staleTime: staleTime.users,
+  });
+
   return (
     <ApplicantCard>
       <ProfileImg
-        src={applicant.profileURL}
-        alt={applicant.displayName}
+        src={applierInfoData.photoURL}
+        alt={applierInfoData.displayName}
         referrerPolicy="no-referrer"
         onClick={() => navigate(`/profile/${applicant.uid}`)}
       />
       <UserInfoDiv>
         <Position>{applicant.position}</Position>
-        <DisplayName>{applicant.displayName}</DisplayName>
+        <DisplayName>{applierInfoData.displayName}</DisplayName>
         <Stacks>
           <UserStacks stacks={applicant.skills} version="mobile"></UserStacks>
         </Stacks>

--- a/src/components/projectDetail/mobile/MobileMemberInfoArea.tsx
+++ b/src/components/projectDetail/mobile/MobileMemberInfoArea.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
-import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { logEvent } from 'utils/amplitude';
+import ParticipantsProfile from '../ParticipantsProfile';
 
 const MobileMemberInfoArea = ({ applicantsData }: any) => {
   const navigate = useNavigate();
@@ -43,13 +43,12 @@ const MobileMemberInfoArea = ({ applicantsData }: any) => {
               {data?.map((key) => {
                 if (applicantsData[key].position === '기획')
                   return (
-                    <MemberProfileImg
+                    <ParticipantsProfile
                       key={key}
-                      onClick={() => onClickEvent(applicantsData[key].uid)}
-                      src={applicantsData[key].profileURL}
-                      alt={applicantsData[key].displayName}
-                      referrerPolicy="no-referrer"
-                    ></MemberProfileImg>
+                      LinkToPublicProfile={onClickEvent}
+                      participantsUid={applicantsData[key].uid}
+                      version="mobile"
+                    />
                   );
               })}
             </MemberInfoObject>
@@ -60,13 +59,12 @@ const MobileMemberInfoArea = ({ applicantsData }: any) => {
               {data?.map((key) => {
                 if (applicantsData[key].position === '디자인')
                   return (
-                    <MemberProfileImg
+                    <ParticipantsProfile
                       key={key}
-                      onClick={() => onClickEvent(applicantsData[key].uid)}
-                      src={applicantsData[key].profileURL}
-                      alt={applicantsData[key].displayName}
-                      referrerPolicy="no-referrer"
-                    ></MemberProfileImg>
+                      LinkToPublicProfile={onClickEvent}
+                      participantsUid={applicantsData[key].uid}
+                      version="mobile"
+                    />
                   );
               })}
             </MemberInfoObject>
@@ -77,13 +75,12 @@ const MobileMemberInfoArea = ({ applicantsData }: any) => {
               {data?.map((key) => {
                 if (applicantsData[key].position === '프론트엔드')
                   return (
-                    <MemberProfileImg
+                    <ParticipantsProfile
                       key={key}
-                      onClick={() => onClickEvent(applicantsData[key].uid)}
-                      src={applicantsData[key].profileURL}
-                      alt={applicantsData[key].displayName}
-                      referrerPolicy="no-referrer"
-                    ></MemberProfileImg>
+                      LinkToPublicProfile={onClickEvent}
+                      participantsUid={applicantsData[key].uid}
+                      version="mobile"
+                    />
                   );
               })}
             </MemberInfoObject>
@@ -94,13 +91,12 @@ const MobileMemberInfoArea = ({ applicantsData }: any) => {
               {data?.map((key) => {
                 if (applicantsData[key].position === '백엔드')
                   return (
-                    <MemberProfileImg
+                    <ParticipantsProfile
                       key={key}
-                      onClick={() => onClickEvent(applicantsData[key].uid)}
-                      src={applicantsData[key].profileURL}
-                      alt={applicantsData[key].displayName}
-                      referrerPolicy="no-referrer"
-                    ></MemberProfileImg>
+                      LinkToPublicProfile={onClickEvent}
+                      participantsUid={applicantsData[key].uid}
+                      version="mobile"
+                    />
                   );
               })}
             </MemberInfoObject>

--- a/src/components/projectDetail/mobile/MobileModal/MobileInviteModal.tsx
+++ b/src/components/projectDetail/mobile/MobileModal/MobileInviteModal.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { updateAppliedProject, updateParticipants } from 'apis/postDetail';
 import COLORS from 'assets/styles/colors';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getUserInfoData } from 'apis/mypageUsers';
+import { updateAppliedProject, updateParticipants } from 'apis/postDetail';
 import MobileAlert from 'components/common/mobile/MobileAlert';
 import { amplitudeToNoneButtonClick } from 'utils/amplitude';
+import { staleTime } from 'utils/staleTime';
 
 const MobileInviteModal = ({
   pid,
@@ -41,6 +43,13 @@ const MobileInviteModal = ({
     }
   };
 
+  // 유저 정보 받아오는 쿼리
+  const { data: applierInfoData }: any = useQuery({
+    queryKey: ['users', applicant?.uid],
+    queryFn: getUserInfoData,
+    staleTime: staleTime.users,
+  });
+
   return (
     <>
       <BackDrop onClick={handleBackDropClick} isOpen={isOpen}>
@@ -60,7 +69,7 @@ const MobileInviteModal = ({
             )}
           </StackDiv>
           <NickNameDiv>
-            <NickName>{applicant.displayName} 님을</NickName>
+            <NickName>{applierInfoData.displayName} 님을</NickName>
             <NickName>팀원으로 초대할까요?</NickName>
             <MotiveDiv>
               <MotiveTitle>지원 동기</MotiveTitle>

--- a/src/hooks/useApply.ts
+++ b/src/hooks/useApply.ts
@@ -61,8 +61,6 @@ const useApply = ({ isOpen, onClickEvent, pid }: props) => {
     updateApplicants(
       pid, //pid로 수정
       uid,
-      userData?.displayName,
-      userData?.photoURL,
       skills,
       positionList[clickValue].name,
       motive,

--- a/src/hooks/useDetailProject.ts
+++ b/src/hooks/useDetailProject.ts
@@ -85,7 +85,7 @@ const useDetailProject = () => {
     // applicants map을 array로 변경
     const applicantsUidArray = Object.keys(applicants);
 
-    applicantsUidArray.forEach((applicant: any) => {
+    applicantsUidArray.forEach((applicant: string) => {
       if (!params.id) return;
       sendNotification({
         title: '지원하신 프로젝트의 모집이 마감되었습니다.',

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -5,7 +5,7 @@ import { useRecoilState } from 'recoil';
 import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 import { useAuth } from 'hooks';
 import {
-  firebaseGetLikdCountRequest,
+  firebaseGetLikedCountRequest,
   firebaseInfinityScrollProjectDataRequest,
 } from 'apis/boardService';
 import { firebaseFindMyInterestRequest } from 'apis/userService';
@@ -92,7 +92,7 @@ const useFindProject = () => {
   };
 
   const handleUpdateLikedCount = useCallback(async (id: string) => {
-    const likeCount = await firebaseGetLikdCountRequest(id);
+    const likeCount = await firebaseGetLikedCountRequest(id);
     setProjects((prev) =>
       prev.map((project) =>
         project.id === id ? { ...project, like: likeCount } : project,

--- a/src/hooks/usePublicProfile.ts
+++ b/src/hooks/usePublicProfile.ts
@@ -17,7 +17,7 @@ import useProjectList from './useProjectList';
 
 const usePubicProfile = () => {
   const params = useParams();
-  const pid = params.id as string; //받는사람 id
+  const receiverId = params?.id as string; //받는사람 id
   const { uid } = useAuth(); //보내는 사람 id (현재 로그인한 유저)
   const { activeProjectTab, handleProjectTabClick, setActiveProjectTab } =
     useProjectList();
@@ -28,18 +28,18 @@ const usePubicProfile = () => {
     queries: [
       //유저 정보 조회
       {
-        queryKey: ['users', pid],
+        queryKey: ['users', receiverId],
         queryFn: getUserInfoData,
         staleTime: staleTime.user,
-        enabled: !!pid,
+        enabled: !!receiverId,
         suspense: true,
       },
       //유저가 참여한 프로젝트 조회
       {
-        queryKey: ['myProjects', pid],
+        queryKey: ['myProjects', receiverId],
         queryFn: getUserProjectList,
         staleTime: staleTime.myProjects,
-        enabled: !!pid,
+        enabled: !!receiverId,
         suspense: true,
       },
     ],
@@ -49,7 +49,7 @@ const usePubicProfile = () => {
     openModalWithData(modalTypes.sendNote, {
       id: 'id', //addDoc이라 id 필요없음
       senderUid: uid,
-      receiverUid: pid,
+      receiverUid: receiverId,
       date: 0,
       title: '',
       content: '',
@@ -69,7 +69,7 @@ const usePubicProfile = () => {
     logEvent('Visit Page', {
       from: `${getCurrentPathName()}`,
       to: 'none',
-      name: 'puplic_profile',
+      name: 'public_profile',
     });
   }, []);
 


### PR DESCRIPTION
## 개요 🔎

Closes #428 
프로필 변경 시 공개프로필의 프로젝트 목록과 상세페이지의 초대하기 모달, 지원자 목록, 참여자 목록에 반영이 안됐던 문제를 해결하였습니다.

## 작업사항 📝
- 상페페이지 지원자 목록 프로필 uid로 조회
- 상세페이지 참여자 목록 프로필 uid로 조회
- 초대하기 모달 지원자 프로필 uid로 조회
- 공개프로필의 참여자 목록 프로필 uid로 조회