### PR TITLE
[fix] 무한 스크롤 로직 변경 및 콘텐츠 카드 하트 수정

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, memo } from 'react';
+import { useEffect, memo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateRecruiting } from 'apis/postDetail';
 import { getDate, getDays } from 'utils/date';
@@ -191,7 +191,35 @@ const ContentCardDate = styled.div`
     color: ${COLORS.gray850}; //색상표에 없음
   }
 `;
-const ContentCardBookmark = styled.div``;
+const ContentCardBookmark = styled.div`
+  transition: transform 0.3s ease;
+  &:hover {
+    transform: scale(1.1);
+  }
+  &:active {
+    animation-name: beat;
+    animation-duration: 1000ms;
+    animation-iteration-count: 1;
+    animation-timing-function: ease-in-out;
+    @keyframes beat {
+      0% {
+        transform: rotate(0deg);
+      }
+      25% {
+        transform: rotate(-10deg);
+      }
+      50% {
+        transform: rotate(10deg);
+      }
+      75% {
+        transform: rotate(-10deg);
+      }
+      100% {
+        transform: rotate(0deg);
+      }
+    }
+  }
+`;
 const ContentCardTitle = styled.div`
   width: 21.875rem;
   height: 3.125rem;

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -186,8 +186,10 @@ const DeadLineIcon = styled.div<{ day: number }>`
 
 const ContentCardLikeBox = styled.div`
   position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
   bottom: 0.25rem;
-  right: 0.25rem;
+  left: 0.25rem;
   transition: transform 0.3s ease;
   &:hover {
     transform: scale(1.1);

--- a/src/components/MobileContentCard.tsx
+++ b/src/components/MobileContentCard.tsx
@@ -1,12 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateRecruiting } from 'apis/postDetail';
-import { firebaseLikeProjectUpdateRequest } from 'apis/boardService';
 import { useAuth, useGlobalModal } from 'hooks';
 import { getDate, getDays } from 'utils/date';
-import { getCurrentPathName, logEvent } from 'utils/amplitude';
 import { EditType } from 'types/write/writeType';
-import { AiOutlineHeart, AiFillHeart } from 'react-icons/ai';
 import defaultThumbnail from 'assets/images/thumbnail_mobile.png';
 import COLORS from 'assets/styles/colors';
 import styled from '@emotion/styled';
@@ -23,7 +20,6 @@ const MobileContentCard = ({
   pid,
   project,
   likedProjects,
-  onUpdateLikedCountEvent,
   onNavigateToProjectDetailEvent,
 }: Props) => {
   const {
@@ -36,12 +32,9 @@ const MobileContentCard = ({
     isRecruiting,
     deadline,
   }: any = project;
-  const { uid } = useAuth();
-  const [isLike, setIsLike] = useState<boolean>(false);
   const idList: any[] = [];
   const queryClient = useQueryClient();
   const today = new Date().getTime();
-  const { openModal } = useGlobalModal();
 
   const { mutate: updateRecruitingMutate } = useMutation(
     () => updateRecruiting(id as string, false),
@@ -52,37 +45,11 @@ const MobileContentCard = ({
     },
   );
 
-  const { mutate: updateLikeMutate } = useMutation(
-    () => firebaseLikeProjectUpdateRequest(id, uid),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(['likedProjects', uid]);
-        queryClient.invalidateQueries(['myProjects', uid]);
-        onUpdateLikedCountEvent?.(id);
-      },
-    },
-  );
-
-  const handleUpdateLike = useCallback(() => {
-    if (!uid) {
-      openModal('login', 0);
-      return;
-    }
-    setIsLike(!isLike);
-    updateLikeMutate();
-    logEvent('Button Click', {
-      from: getCurrentPathName(),
-      to: 'none',
-      name: 'like',
-    });
-  }, [isLike, updateLikeMutate, uid]);
-
   useEffect(() => {
     if (today > deadline) {
       idList.push(id);
       updateRecruitingMutate(id, false as any);
     }
-    setIsLike(likedProjects?.includes(id ?? pid) ?? false);
   }, [likedProjects]);
 
   useEffect(() => {
@@ -105,7 +72,9 @@ const MobileContentCard = ({
             alt={title + '프로젝트 썸네일'}
           />
         )}
-        <Likes pid={id} page="card" />
+        <ContentCardLikeBox onClick={(e) => e.stopPropagation()}>
+          <Likes pid={id} page="card" />
+        </ContentCardLikeBox>
       </ContentCardImgContainer>
       <ContentCardContentsContainer
         onClick={onNavigateToProjectDetailEvent(id ?? pid)}
@@ -215,12 +184,10 @@ const DeadLineIcon = styled.div<{ day: number }>`
   color: ${({ day }) => (day <= 3 ? `${COLORS.white}` : `${COLORS.gray400}`)};
 `;
 
-const ContentCardBookmark = styled.button`
+const ContentCardLikeBox = styled.div`
   position: absolute;
-  width: 1.5rem;
-  height: 1.5rem;
   bottom: 0.25rem;
-  left: 0.25rem;
+  right: 0.25rem;
   transition: transform 0.3s ease;
   &:hover {
     transform: scale(1.1);

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -1,13 +1,10 @@
-import { useEffect, useState, useCallback, MouseEvent } from 'react';
+import { useEffect, useState, MouseEvent } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { useRecoilState } from 'recoil';
 import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 import { useAuth } from 'hooks';
-import {
-  firebaseGetLikedCountRequest,
-  firebaseInfinityScrollProjectDataRequest,
-} from 'apis/boardService';
+import { firebaseInfinityScrollProjectDataRequest } from 'apis/boardService';
 import { firebaseFindMyInterestRequest } from 'apis/userService';
 import { findProjectCategoryState } from '../recoil/atoms';
 import { EditType } from 'types/write/writeType';
@@ -21,7 +18,6 @@ const useFindProject = () => {
   const { uid } = useAuth();
 
   const [projects, setProjects] = useState<EditType.EditFormType[]>([]);
-  const [lastVisible, setLastVisible] = useState<any>(undefined);
   const [category, setCategory] = useRecoilState(findProjectCategoryState);
   const [toggle, setToggle] = useState<boolean>(false);
 
@@ -33,13 +29,22 @@ const useFindProject = () => {
     suspense: true,
   });
 
-  useEffect(() => {
-    firebaseInfinityScrollProjectDataRequest(
-      setProjects,
-      lastVisible,
-      setLastVisible,
-    );
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    ['post'],
+    firebaseInfinityScrollProjectDataRequest,
+    {
+      getNextPageParam: (lastPage) => lastPage[lastPage.length - 1]?.createdAt,
+      onSuccess: (data) => {
+        setProjects(() => [...data.pages.flat()]);
+      },
+    },
+  );
 
+  useBottomScrollListener(() => {
+    if (!isFetchingNextPage && hasNextPage) fetchNextPage();
+  });
+
+  useEffect(() => {
     window.onbeforeunload = () => {
       window.scrollTo(0, 0);
     };
@@ -50,18 +55,6 @@ const useFindProject = () => {
       setCategory(categoryFromFooter);
     }
   }, [categoryFromFooter]);
-
-  useBottomScrollListener(
-    useCallback(() => {
-      if (lastVisible) {
-        firebaseInfinityScrollProjectDataRequest(
-          setProjects,
-          lastVisible,
-          setLastVisible,
-        );
-      }
-    }, [lastVisible]),
-  );
 
   const handleCategoryClick = (e: MouseEvent<HTMLButtonElement>) => {
     const { name } = e.target as HTMLButtonElement;
@@ -91,15 +84,6 @@ const useFindProject = () => {
     navigate(`/project/${path}`);
   };
 
-  const handleUpdateLikedCount = useCallback(async (id: string) => {
-    const likeCount = await firebaseGetLikedCountRequest(id);
-    setProjects((prev) =>
-      prev.map((project) =>
-        project.id === id ? { ...project, like: likeCount } : project,
-      ),
-    );
-  }, []);
-
   return {
     toggle,
     projects,
@@ -107,7 +91,6 @@ const useFindProject = () => {
     likedProjects,
     handleToggleClick,
     handleCategoryClick,
-    handleUpdateLikedCount,
     handleNavigateToProjectDetail,
   };
 };


### PR DESCRIPTION
## 개요 :mag_right:

무한 스크롤 로직 tanstack react query 로직으로 변경
콘텐츠 카드 좋아요 위치 변경 및 클릭시 디테일로 가는 버그 수정

## 작업사항 :pencil:

- 무한 스크롤 로직 useInfiniteQuery 를 통해서 가져오도록 수정
- 콘텐츠 카드 좋아요 아이콘 위치 조정
- 콘텐츠 카드 좋아요 클릭시 디테일로 가능 부분 수정

## 패키지 설치내용 :package: