### PR TITLE
[fix] 상세보기 새로고침 시 하트, 작성자 공개프로필 링크 이동 이벤트 영역 수정

### DIFF
--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -10,8 +10,9 @@ import {
 } from 'firebase/firestore';
 
 //좋아요 수 업데이트
-export const updateLike = async (pid: any, countLike: any) => {
+export const updateLike = async (pid: string, countLike: number) => {
   if (pid === undefined) return;
+  if (countLike === undefined) return;
   const docRef = doc(firestore, 'post', pid);
   try {
     await updateDoc(docRef, { like: countLike });

--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -78,14 +78,20 @@ const Likes = ({ pid, version = 'web', page = 'detail' }: Props) => {
       },
     },
   );
+
   useEffect(() => {
     updateMyProjectMutate();
     updateLikeMutate();
-  }, [isLike]);
+  }, [isLike, countLike]);
 
   useEffect(() => {
     setCountLike(projectLike?.like);
   }, [projectLike?.like]);
+
+  // 새로고침 시 myProjects가 늦게 불러와져서 추가한 useEffect
+  useEffect(() => {
+    setIsLike(myProjects?.likedProjects?.includes(pid));
+  }, [myProjects?.likedProjects]);
 
   return (
     <IconButton

--- a/src/components/projectDetail/WriterToShareArea.tsx
+++ b/src/components/projectDetail/WriterToShareArea.tsx
@@ -11,18 +11,19 @@ const WriterToShareArea = ({ pid, userData, projectData }: any) => {
 
   return (
     <WriterToShareContainer>
-      <WriterWrapper>
+      <WriterWrapper
+        onClick={() => {
+          navigate(`/profile/${uid}`);
+          logEvent('Button Click', {
+            from: `project_detail`, //pahtname으로 설정 시 이동한 페이지로 인식해서 수정
+            to: 'profile',
+            name: 'profile',
+          });
+        }} //작성자 공개 프로필 페이지로 이동
+      >
         <WriterProfileImg
           src={userData?.photoURL}
           alt={userData?.displayName}
-          onClick={() => {
-            navigate(`/profile/${uid}`);
-            logEvent('Button Click', {
-              from: `project_detail`, //pahtname으로 설정 시 이동한 페이지로 인식해서 수정
-              to: 'profile',
-              name: 'profile',
-            });
-          }} //작성자 공개 프로필 페이지로 이동
           referrerPolicy="no-referrer"
         />
         <WriterNickname>{userData?.displayName ?? `닉네임`}</WriterNickname>
@@ -47,6 +48,7 @@ const WriterToShareContainer = styled.div`
 const WriterWrapper = styled.div`
   display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 const IconWrapper = styled.div`
@@ -62,7 +64,6 @@ const WriterProfileImg = styled.img`
   height: 2rem;
   border-radius: 50%;
   object-fit: cover;
-  cursor: pointer;
 `;
 
 const WriterNickname = styled.p`

--- a/src/components/projectDetail/mobile/MobileWirterToProjectInfoArea.tsx
+++ b/src/components/projectDetail/mobile/MobileWirterToProjectInfoArea.tsx
@@ -21,22 +21,24 @@ const WriterToProjectInfoArea = ({ projectData, userData }: any) => {
 
   return (
     <WriterToProjectInfoContainer>
-      <WriterWrapper
-        onClick={() => {
-          navigate(`/profile/${uid}`);
-          logEvent('Button Click', {
-            from: `project_detail`, //pathname으로 하면 이동한페이지로 인식해서 수정
-            to: 'profile',
-            name: 'profile',
-          });
-        }}
-      >
-        <WriterProfileImg
-          src={userData?.photoURL}
-          alt={userData?.displayName}
-          referrerPolicy="no-referrer"
-        />
-        <WriterNickname>{userData?.displayName}</WriterNickname>
+      <WriterWrapper>
+        <WriterBox
+          onClick={() => {
+            navigate(`/profile/${uid}`);
+            logEvent('Button Click', {
+              from: `project_detail`, //pathname으로 하면 이동한페이지로 인식해서 수정
+              to: 'profile',
+              name: 'profile',
+            });
+          }}
+        >
+          <WriterProfileImg
+            src={userData?.photoURL}
+            alt={userData?.displayName}
+            referrerPolicy="no-referrer"
+          />
+          <WriterNickname>{userData?.displayName}</WriterNickname>
+        </WriterBox>
       </WriterWrapper>
       <ProjectInfoWrapper>
         <ProjectInfoObject>
@@ -119,10 +121,14 @@ const WriterToProjectInfoContainer = styled.div`
 `;
 
 const WriterWrapper = styled.div`
-  display: flex;
   margin: 1rem 1.25rem 0 1.25rem;
   height: 2rem;
+`;
+
+const WriterBox = styled.div`
+  display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 const WriterProfileImg = styled.img`


### PR DESCRIPTION
## 개요 🔎

Closes #438 #439 

상세보기 새로고침 시 하트 유지,
작성자 공개프로필 링크 이동 이벤트 영역을 수정했습니다.

## 작업사항 📝

* 새로고침 시 하트 유지되도록 useEffect문 추가
* 메인,프로젝트 찾기 페이지에서 초기에 countLike가 undefined일 때의 에러 예외처리
* 모바일 상세보기 -> 작성자 공개 프로필 이동 영역 수정 (해당 div 어디든 -> 사진 닉네임 영역)
* 데스크탑 상세보기 -> 작성자 공개 프로필 이동 영역 수정 (프로필 사진 -> 사진,닉네임 영역) 


## 패키지 설치내용 📦
.