### PR TITLE
[fix] 콘텐츠 카드와 특정 디테일 게시판 버그 수정

### DIFF
--- a/src/components/projectDetail/Likes.tsx
+++ b/src/components/projectDetail/Likes.tsx
@@ -75,6 +75,7 @@ const Likes = ({ pid, version = 'web', page = 'detail' }: Props) => {
         queryClient.invalidateQueries(['post', 'mostViewed']);
         queryClient.invalidateQueries(['post', 'mostLiked']);
         queryClient.invalidateQueries(['likedProjects', uid]);
+        queryClient.invalidateQueries(['post', 'findProject']);
       },
     },
   );

--- a/src/components/projectDetail/mobile/MobileModal/MobileInviteModal.tsx
+++ b/src/components/projectDetail/mobile/MobileModal/MobileInviteModal.tsx
@@ -69,7 +69,7 @@ const MobileInviteModal = ({
             )}
           </StackDiv>
           <NickNameDiv>
-            <NickName>{applierInfoData.displayName} 님을</NickName>
+            <NickName>{applierInfoData?.displayName} 님을</NickName>
             <NickName>팀원으로 초대할까요?</NickName>
             <MotiveDiv>
               <MotiveTitle>지원 동기</MotiveTitle>

--- a/src/hooks/useFindProject.ts
+++ b/src/hooks/useFindProject.ts
@@ -30,7 +30,7 @@ const useFindProject = () => {
   });
 
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
-    ['post'],
+    ['post', 'findProject'],
     firebaseInfinityScrollProjectDataRequest,
     {
       getNextPageParam: (lastPage) => lastPage[lastPage.length - 1]?.createdAt,


### PR DESCRIPTION
## 개요 :mag_right:

Closed #441 #442 

PC 콘텐츠 카드 관심수 카운트 제대로 적용 안되는 버그 수정
Mobile 특정 디테일 게시판 displayName 에러 수정

## 작업사항 :pencil:

- 팀원찾기 페이지 useInfiniteQuery 의 querykey invalid 처리
- 디테일 페이지 InviteModal displayName optional chaining 적용

## 패키지 설치내용 :package:

`적용했던 Package의 install 명령어를 남겨주세요.`