### PR TITLE
[fix] 토스트 팝업 모바일 사이즈 추가 및 콘솔 삭제

### DIFF
--- a/src/components/common/ValidationToastPopup.tsx
+++ b/src/components/common/ValidationToastPopup.tsx
@@ -57,7 +57,6 @@ const ValidationToastAlertIcon = styled.div<Partial<Props>>`
   width: 5%;
   height: ${(props) => (props.isMobile ? '100%' : '')};
   display: ${(props) => (props.isMobile ? 'flex' : 'none')};
-  /* justify-content: ${(props) => (props.isMobile ? 'center' : '')}; */
   text-align: center;
   align-items: center;
 `;

--- a/src/components/common/ValidationToastPopup.tsx
+++ b/src/components/common/ValidationToastPopup.tsx
@@ -1,3 +1,4 @@
+import { useIsMobile } from 'hooks';
 import styled from '@emotion/styled';
 import COLORS from 'assets/styles/colors';
 
@@ -6,12 +7,15 @@ interface Props {
   top?: number;
   isCopy?: boolean;
   isCheck?: boolean;
+  isMobile?: boolean;
 }
 
 const ValidationToastPopup = ({ message, top, isCopy, isCheck }: Props) => {
+  const isMobile = useIsMobile();
+
   return (
-    <ValidationToastAlertContainer top={top}>
-      <ValidationToastAlertIcon>{`${
+    <ValidationToastAlertContainer top={top} isMobile={isMobile}>
+      <ValidationToastAlertIcon isMobile={isMobile}>{`${
         isCopy ? '🔗' : isCheck ? '✅' : '❌'
       }`}</ValidationToastAlertIcon>
       <ValidationToastAlertText>{message}</ValidationToastAlertText>
@@ -20,29 +24,22 @@ const ValidationToastPopup = ({ message, top, isCopy, isCheck }: Props) => {
 };
 
 const ValidationToastAlertContainer = styled.div<Partial<Props>>`
+  width: ${(props) => (props.isMobile ? '90%' : '30%')};
+  height: ${(props) => (props.isMobile ? '1.8rem' : '2.5rem')};
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   padding: 0.5rem 0.625rem;
   gap: 0.625rem;
-
-  width: 23rem;
-  height: 2.5rem;
-
   position: fixed;
-
   top: ${(props) => (props.top ? `${props.top}rem` : '15%')};
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 100;
-
   background: linear-gradient(180deg, #9586ef 0%, #7a67ec 100%);
-
   filter: drop-shadow(0rem 0rem 0.625rem rgba(0, 0, 0, 0.25));
   backdrop-filter: blur(0.4375rem);
-
   border-radius: 0.625rem;
-
   animation: toast 0.5s ease-in-out;
   @keyframes toast {
     0% {
@@ -55,23 +52,25 @@ const ValidationToastAlertContainer = styled.div<Partial<Props>>`
     }
   }
 `;
-const ValidationToastAlertIcon = styled.div`
+
+const ValidationToastAlertIcon = styled.div<Partial<Props>>`
   width: 5%;
+  height: ${(props) => (props.isMobile ? '100%' : '')};
+  display: ${(props) => (props.isMobile ? 'flex' : 'none')};
+  /* justify-content: ${(props) => (props.isMobile ? 'center' : '')}; */
   text-align: center;
   align-items: center;
 `;
+
 const ValidationToastAlertText = styled.p`
   width: 95%;
   height: 100%;
-
   font-weight: 500;
-  font-size: 0.9375rem;
+  font-size: 0.8rem;
   line-height: 1.5rem;
-
   display: flex;
   align-items: center;
   justify-content: center;
-
   color: ${COLORS.white};
 `;
 

--- a/src/hooks/useEditBoard.ts
+++ b/src/hooks/useEditBoard.ts
@@ -6,6 +6,8 @@ import {
   MouseEvent,
   useEffect,
 } from 'react';
+import { useRecoilValue } from 'recoil';
+import { deletedPidState } from '../recoil/atoms';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { firebaseEditProjectRequest } from 'apis/boardService';
@@ -20,8 +22,6 @@ import {
   titleValidation,
 } from 'utils/validation';
 import Resizer from 'react-image-file-resizer';
-import { useRecoilValue } from 'recoil';
-import { deletedPidState } from '../recoil/atoms';
 
 const useEditBoard = () => {
   const { state } = useLocation();
@@ -32,7 +32,7 @@ const useEditBoard = () => {
   const editRef = useRef<any>(null);
   const imageRef = useRef<any>(null);
 
-  console.log(imageRef);
+  const deletedPid = useRecoilValue(deletedPidState);
 
   const [editFormValue, setEditFormValue] = useState<EditType.EditFormType>(
     state || JSON.parse(sessionStorage.getItem('editFormValue') || '{}'),
@@ -218,7 +218,6 @@ const useEditBoard = () => {
     return navigate(-2);
   }, []);
 
-  const deletedPid = useRecoilValue(deletedPidState);
   useEffect(() => {
     (() => {
       if (deletedPid) return;


### PR DESCRIPTION
## 개요 :mag_right:

- 토스트 팝업 메시지 모바일 사이즈 추가
- console.log 이력 삭제

## 작업사항 :pencil:

- Toast Message Popup isMobile 사이즈 추가
- useEditBoard 에 imgRef console.log 삭제

## 패키지 설치내용 :package:

`적용했던 Package의 install 명령어를 남겨주세요.`