### PR TITLE
[fix] Toast Message Popup 모바일 CSS 수정

### DIFF
--- a/src/components/common/ValidationToastPopup.tsx
+++ b/src/components/common/ValidationToastPopup.tsx
@@ -18,7 +18,9 @@ const ValidationToastPopup = ({ message, top, isCopy, isCheck }: Props) => {
       <ValidationToastAlertIcon isMobile={isMobile}>{`${
         isCopy ? '🔗' : isCheck ? '✅' : '❌'
       }`}</ValidationToastAlertIcon>
-      <ValidationToastAlertText>{message}</ValidationToastAlertText>
+      <ValidationToastAlertText isMobile={isMobile}>
+        {message}
+      </ValidationToastAlertText>
     </ValidationToastAlertContainer>
   );
 };
@@ -61,11 +63,11 @@ const ValidationToastAlertIcon = styled.div<Partial<Props>>`
   align-items: center;
 `;
 
-const ValidationToastAlertText = styled.p`
+const ValidationToastAlertText = styled.p<Partial<Props>>`
   width: 95%;
   height: 100%;
   font-weight: 500;
-  font-size: 0.8rem;
+  font-size: ${(props) => (props.isMobile ? '0.7rem' : '0.8rem')};
   line-height: 1.5rem;
   display: flex;
   align-items: center;

--- a/src/components/common/ValidationToastPopup.tsx
+++ b/src/components/common/ValidationToastPopup.tsx
@@ -26,7 +26,7 @@ const ValidationToastPopup = ({ message, top, isCopy, isCheck }: Props) => {
 };
 
 const ValidationToastAlertContainer = styled.div<Partial<Props>>`
-  width: ${(props) => (props.isMobile ? '90%' : '30%')};
+  width: ${(props) => (props.isMobile ? '90%' : '23rem')};
   height: ${(props) => (props.isMobile ? '1.8rem' : '2.5rem')};
   display: flex;
   flex-direction: row;
@@ -58,7 +58,7 @@ const ValidationToastAlertContainer = styled.div<Partial<Props>>`
 const ValidationToastAlertIcon = styled.div<Partial<Props>>`
   width: 5%;
   height: ${(props) => (props.isMobile ? '100%' : '')};
-  display: ${(props) => (props.isMobile ? 'flex' : 'none')};
+  display: ${(props) => (props.isMobile ? 'flex' : '')};
   text-align: center;
   align-items: center;
 `;


### PR DESCRIPTION
## 개요 :mag_right:

- 토스트 메시지 팝업창 400px 미만에서 글자크기 깨지는 부분 수정
- PC 버전 display: 'none' 으로 인한 CSS버그 수정

## 작업사항 :pencil:

- isMobile 일때 텍스트 사이즈 조정
- PC일때 display: 'none' -> '' 로 수정

## 패키지 설치내용 :package:

`적용했던 Package의 install 명령어를 남겨주세요.`